### PR TITLE
fix:HoursTracker refresh when submitting hours

### DIFF
--- a/src/app/components/TimerCard/TimerCard.tsx
+++ b/src/app/components/TimerCard/TimerCard.tsx
@@ -10,8 +10,9 @@ import { TextArea } from "@/app/components/ui/TextArea/TextArea";
 import { ConfirmationModal } from "@/app/components/ui/ConfirmationModal/ConfirmationModal";
 
 interface TimerCardContentProps {
-  onConfirmFinish: () => void;
+  onConfirmFinish: () => Promise<void>;
 }
+
 const TimerCardContent = ({ onConfirmFinish }: TimerCardContentProps) => {
   const { isRunning, startTimer, stopTimer, resetTimer } = useTimer();
   const [description, setDescription] = useState("");
@@ -71,7 +72,7 @@ const TimerCardContent = ({ onConfirmFinish }: TimerCardContentProps) => {
   return (
     <>
       <Card
-        title="Registro de Horas"
+        title="Controle de Horas"
         icon="arrow"
         classContent="h-full flex flex-col items-center justify-center relative"
       >
@@ -128,4 +129,6 @@ const TimerCardContent = ({ onConfirmFinish }: TimerCardContentProps) => {
   );
 };
 
-export const TimerCard = ({ onConfirmFinish }: TimerCardContentProps) => <TimerCardContent onConfirmFinish={onConfirmFinish} />;
+export const TimerCard = ({ onConfirmFinish }: TimerCardContentProps) => (
+  <TimerCardContent onConfirmFinish={onConfirmFinish} />
+);

--- a/src/app/components/TimerCard/TimerCard.tsx
+++ b/src/app/components/TimerCard/TimerCard.tsx
@@ -9,7 +9,10 @@ import { TimerDisplay } from "@/app/components/ui/TimerDisplay";
 import { TextArea } from "@/app/components/ui/TextArea/TextArea";
 import { ConfirmationModal } from "@/app/components/ui/ConfirmationModal/ConfirmationModal";
 
-const TimerCardContent = () => {
+interface TimerCardContentProps {
+  onConfirmFinish: () => void;
+}
+const TimerCardContent = ({ onConfirmFinish }: TimerCardContentProps) => {
   const { isRunning, startTimer, stopTimer, resetTimer } = useTimer();
   const [description, setDescription] = useState("");
   const [error, setError] = useState<string | undefined>(undefined);
@@ -46,6 +49,7 @@ const TimerCardContent = () => {
     setIsStopping(true);
     try {
       await stopTimer(description);
+      await onConfirmFinish();
       resetTimer();
       setDescription("");
       setIsModalOpen(false);
@@ -124,4 +128,4 @@ const TimerCardContent = () => {
   );
 };
 
-export const TimerCard = () => <TimerCardContent />;
+export const TimerCard = ({ onConfirmFinish }: TimerCardContentProps) => <TimerCardContent onConfirmFinish={onConfirmFinish} />;

--- a/src/app/pages/DashboardPage.tsx
+++ b/src/app/pages/DashboardPage.tsx
@@ -37,9 +37,10 @@ export default function DashboardPage() {
   const { updateUser } = useAuth();
   const [profile, setProfile] = useState<ProfileData | null>(null);
   const [hours, setHours] = useState<HoursData | null>(null);
-  const [hoursLoading, setHoursLoading] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [hoursLoading, setHoursLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
   useEffect(() => {
     api
       .get<DashboardResponse>("/dashboard")
@@ -49,18 +50,17 @@ export default function DashboardPage() {
         updateUser({ level: toAgesLevel(data.profile.agesLevel) });
       })
       .catch((err: Error) => setError(err.message))
-      .finally(() => {
-        setLoading(false);
-    });
+      .finally(() => setLoading(false));
   }, []);
-  const refreshHours = () => {
-  setHoursLoading(true)
-  api
-    .get<HoursData>("/hours/me/control")
-    .then((data) => setHours(data))
-    .catch((err: Error) => setError(err.message))
-    .finally(() => setHoursLoading(false))
-}
+
+  const refreshHours = (): Promise<void> => {
+    setHoursLoading(true);
+    return api
+      .get<HoursData>("/hours/me/control")
+      .then((data) => setHours(data))
+      .catch((err: Error) => setError(err.message))
+      .finally(() => setHoursLoading(false));
+  };
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-3 lg:rows-[auto_1fr] lg:h-full gap-6">
@@ -69,11 +69,15 @@ export default function DashboardPage() {
       </div>
 
       <div className="lg:col-span-2 flex flex-col">
-        <TimerCard onConfirmFinish={refreshHours}/>
+        <TimerCard onConfirmFinish={refreshHours} />
       </div>
 
       <div className="lg:col-span-3">
-        <HoursTracker hours={hours} loading={loading || hoursLoading} error={error} />
+        <HoursTracker
+          hours={hours}
+          loading={loading || hoursLoading}
+          error={error}
+        />
       </div>
     </div>
   );

--- a/src/app/pages/DashboardPage.tsx
+++ b/src/app/pages/DashboardPage.tsx
@@ -56,8 +56,8 @@ export default function DashboardPage() {
   const refreshHours = () => {
   setHoursLoading(true)
   api
-    .get<DashboardResponse>("/dashboard")
-    .then((data) => setHours(data.hours))
+    .get<HoursData>("/hours/me/control")
+    .then((data) => setHours(data))
     .catch((err: Error) => setError(err.message))
     .finally(() => setHoursLoading(false))
 }

--- a/src/app/pages/DashboardPage.tsx
+++ b/src/app/pages/DashboardPage.tsx
@@ -37,9 +37,9 @@ export default function DashboardPage() {
   const { updateUser } = useAuth();
   const [profile, setProfile] = useState<ProfileData | null>(null);
   const [hours, setHours] = useState<HoursData | null>(null);
+  const [hoursLoading, setHoursLoading] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-
   useEffect(() => {
     api
       .get<DashboardResponse>("/dashboard")
@@ -49,8 +49,18 @@ export default function DashboardPage() {
         updateUser({ level: toAgesLevel(data.profile.agesLevel) });
       })
       .catch((err: Error) => setError(err.message))
-      .finally(() => setLoading(false));
+      .finally(() => {
+        setLoading(false);
+    });
   }, []);
+  const refreshHours = () => {
+  setHoursLoading(true)
+  api
+    .get<DashboardResponse>("/dashboard")
+    .then((data) => setHours(data.hours))
+    .catch((err: Error) => setError(err.message))
+    .finally(() => setHoursLoading(false))
+}
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-3 lg:rows-[auto_1fr] lg:h-full gap-6">
@@ -59,11 +69,11 @@ export default function DashboardPage() {
       </div>
 
       <div className="lg:col-span-2 flex flex-col">
-        <TimerCard />
+        <TimerCard onConfirmFinish={refreshHours}/>
       </div>
 
       <div className="lg:col-span-3">
-        <HoursTracker hours={hours} loading={loading} error={error} />
+        <HoursTracker hours={hours} loading={loading || hoursLoading} error={error} />
       </div>
     </div>
   );


### PR DESCRIPTION
- Após confirmação do encerramento do ponto no modal, chama GET /hours/me/control para buscar os valores atualizados

- Componente de Controle de Horas re-renderiza automaticamente com os novos valores de completedSeconds, remainingSeconds e percentual

- Skeleton de carregamento exibido no componente durante a nova requisição

- Demais componentes do dashboard (ProfileCard, Registro de Horas) não são afetados pela atualização
