### PR TITLE
[US009] [Frontend] - Tela de Relatórios (Container)

### DIFF
--- a/src/app/pages/RelatoriosPage.tsx
+++ b/src/app/pages/RelatoriosPage.tsx
@@ -1,0 +1,108 @@
+import { useState } from "react";
+import { FileText, Download, ChevronDown } from "lucide-react";
+
+type TabId = "horas" | "sprint" | "andamento" | "final";
+
+interface Tab {
+  id: TabId;
+  label: string;
+  hasProjectFilter: boolean;
+}
+
+const TABS: Tab[] = [
+  { id: "horas",     label: "Horas",     hasProjectFilter: true  },
+  { id: "sprint",    label: "Sprint",    hasProjectFilter: true  },
+  { id: "andamento", label: "Andamento", hasProjectFilter: false },
+  { id: "final",     label: "Final",     hasProjectFilter: false },
+];
+
+export default function RelatoriosPage() {
+  const [activeTab, setActiveTab] = useState<TabId>("horas");
+  const [selectedProject, setSelectedProject] = useState("");
+
+  const currentTab = TABS.find((t) => t.id === activeTab)!;
+
+  return (
+    <div className="flex flex-col gap-5">
+      {/* Cabeçalho */}
+      <div className="flex items-center gap-2.5">
+        <FileText size={20} className="text-[#3b5ccc]" strokeWidth={1.8} />
+        <h2 className="text-[18px] font-bold text-[#1f2937] m-0 leading-none">
+          Relatórios
+        </h2>
+      </div>
+
+      {/* Card container */}
+      <div className="bg-white rounded-2xl border border-[#e5e7eb] overflow-hidden">
+
+        {/* Barra de abas */}
+        <div className="flex items-center border-b border-[#e5e7eb] px-6">
+          <nav className="flex flex-1 gap-1" role="tablist">
+            {TABS.map((tab) => {
+              const isActive = tab.id === activeTab;
+              return (
+                <button
+                  key={tab.id}
+                  role="tab"
+                  aria-selected={isActive}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={[
+                    "relative px-4 py-4 text-[14px] font-medium transition-colors focus:outline-none",
+                    isActive
+                      ? "text-[#3b5ccc]"
+                      : "text-[#6b7280] hover:text-[#374151]",
+                  ].join(" ")}
+                >
+                  {tab.label}
+                  {isActive && (
+                    <span className="absolute bottom-0 left-0 right-0 h-[2px] bg-[#3b5ccc] rounded-t-full" />
+                  )}
+                </button>
+              );
+            })}
+          </nav>
+
+          {/* Ícone de download */}
+          <button
+            aria-label="Baixar relatório"
+            className="
+              w-[34px] h-[34px] flex items-center justify-center
+              rounded-lg border border-[#e5e7eb] text-[#6b7280]
+              hover:bg-[#f3f4f6] hover:text-[#3b5ccc] transition-colors
+            "
+          >
+            <Download size={16} strokeWidth={1.8} />
+          </button>
+        </div>
+
+        {/* Filtro compartilhado (Horas + Sprint) */}
+        {currentTab.hasProjectFilter && (
+          <div className="px-6 pt-5">
+            <div className="relative">
+              <select
+                value={selectedProject}
+                onChange={(e) => setSelectedProject(e.target.value)}
+                className="
+                  appearance-none h-[38px] pl-4 pr-9 rounded-lg
+                  border border-[#e5e7eb] bg-white
+                  text-[13px] text-[#6b7280] font-medium
+                  focus:outline-none focus:ring-2 focus:ring-[#3b5ccc]/30 focus:border-[#3b5ccc]
+                  cursor-pointer transition-colors
+                "
+              >
+                <option value="">Filtrar por projeto</option>
+              </select>
+              <ChevronDown
+                size={15}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-[#9ca3af] pointer-events-none"
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Slot – cada aba renderiza seu componente filho */}
+        <div role="tabpanel" className="p-6" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/pages/RelatoriosPage.tsx
+++ b/src/app/pages/RelatoriosPage.tsx
@@ -10,10 +10,10 @@ interface Tab {
 }
 
 const TABS: Tab[] = [
-  { id: "horas",     label: "Horas",     hasProjectFilter: true  },
-  { id: "sprint",    label: "Sprint",    hasProjectFilter: true  },
+  { id: "horas", label: "Horas", hasProjectFilter: true },
+  { id: "sprint", label: "Sprint", hasProjectFilter: true },
   { id: "andamento", label: "Andamento", hasProjectFilter: false },
-  { id: "final",     label: "Final",     hasProjectFilter: false },
+  { id: "final", label: "Final", hasProjectFilter: false },
 ];
 
 export default function RelatoriosPage() {
@@ -34,7 +34,6 @@ export default function RelatoriosPage() {
 
       {/* Card container */}
       <div className="bg-white rounded-2xl border border-[#e5e7eb] overflow-hidden">
-
         {/* Barra de abas */}
         <div className="flex items-center border-b border-[#e5e7eb] px-6">
           <nav className="flex flex-1 gap-1" role="tablist">

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -2,15 +2,17 @@ import { createBrowserRouter, Navigate } from "react-router";
 import LoginPage from "./pages/LoginPage";
 import { AppLayout } from "./components/dashboard/AppLayout";
 import DashboardPage from "./pages/DashboardPage";
+import RelatoriosPage from "./pages/RelatoriosPage";
 
 export const router = createBrowserRouter([
   { path: "/login", Component: LoginPage },
   {
     path: "/",
-    Component: AppLayout,
+    Component: AppLayout,         
     children: [
       { index: true, element: <Navigate to="/dashboard" replace /> },
-      { path: "dashboard", Component: DashboardPage },
+      { path: "dashboard",  Component: DashboardPage  },
+      { path: "relatorios", Component: RelatoriosPage },
     ],
   },
 ]);

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -8,10 +8,10 @@ export const router = createBrowserRouter([
   { path: "/login", Component: LoginPage },
   {
     path: "/",
-    Component: AppLayout,         
+    Component: AppLayout,
     children: [
       { index: true, element: <Navigate to="/dashboard" replace /> },
-      { path: "dashboard",  Component: DashboardPage  },
+      { path: "dashboard", Component: DashboardPage },
       { path: "relatorios", Component: RelatoriosPage },
     ],
   },


### PR DESCRIPTION
## US009 · [Frontend] Tela de Relatórios (Container)

### O que foi feito
Implementa a estrutura base da tela de Relatórios com navegação por abas e filtro de projeto compartilhado.

### Arquivos alterados
- `src/app/pages/RelatoriosPage.tsx` — página criada
- `src/app/routes.tsx` — rota `/relatorios` registrada

### Critérios de aceitação
- [x] Rota `/relatorios` protegida por guard de autenticação (via `AppLayout`)
- [x] Título "Relatórios" com ícone no topo
- [x] Navegação por abas: Horas, Sprint, Andamento, Final
- [x] Aba ativa destacada com underline azul
- [x] Filtro "Filtrar por projeto" compartilhado entre abas Horas e Sprint
- [x] Ícone de download no canto direito das abas
- [x] Slot `tabpanel` pronto para receber componentes filhos

### Observações
- O conteúdo interno de cada aba será implementado em tasks futuras
- O filtro de projeto já expõe `selectedProject` no estado, pronto para ser passado como prop aos filhos

### Imagens

<img width="1500" height="761" alt="Captura de Tela 2026-04-30 às 17 23 03" src="https://github.com/user-attachments/assets/1b65cafd-8dab-46c4-a7a2-dcd5e7cfa63b" />
