### PR TITLE
flu-79-us009-frontend-aba-de-relatorios-de-horas

### DIFF
--- a/src/app/components/reports/HoursSummary.tsx
+++ b/src/app/components/reports/HoursSummary.tsx
@@ -1,0 +1,26 @@
+export function HoursSummary({ data }: { data: any[] }) {
+  const totalSeconds = 60 * 60 * 60; // 60h
+  const doneSeconds = data.reduce(
+    (acc, item) => acc + (item.totalTimeSeconds ?? 0),
+    0
+  );
+  const remainingSeconds = Math.max(totalSeconds - doneSeconds, 0);
+
+  return (
+    <div className="mb-4 rounded-lg bg-blue-50 px-4 py-3 text-sm text-[#3b5ccc]">
+      <span className="font-semibold">
+        {formatHours(doneSeconds)} concluídas
+      </span>{" "}
+      de {formatHours(totalSeconds)} totais —{" "}
+      <span className="font-semibold">
+        {formatHours(remainingSeconds)} restantes
+      </span>{" "}
+      para concluir.
+    </div>
+  );
+}
+
+function formatHours(seconds: number) {
+  const h = Math.floor(seconds / 3600);
+  return `${h}h`;
+}

--- a/src/app/components/reports/HoursSummary.tsx
+++ b/src/app/components/reports/HoursSummary.tsx
@@ -1,8 +1,17 @@
-export function HoursSummary({ data }: { data: any[] }) {
-  const totalSeconds = 60 * 60 * 60; // 60h
+interface HourEntry {
+  totalTimeSeconds: number;
+}
+
+interface HoursSummaryProps {
+  data: HourEntry[];
+  totalHours?: number;
+}
+
+export function HoursSummary({ data, totalHours = 60 }: HoursSummaryProps) {
+  const totalSeconds = totalHours * 3600;
   const doneSeconds = data.reduce(
     (acc, item) => acc + (item.totalTimeSeconds ?? 0),
-    0
+    0,
   );
   const remainingSeconds = Math.max(totalSeconds - doneSeconds, 0);
 
@@ -22,5 +31,7 @@ export function HoursSummary({ data }: { data: any[] }) {
 
 function formatHours(seconds: number) {
   const h = Math.floor(seconds / 3600);
-  return `${h}h`;
+  const m = Math.floor((seconds % 3600) / 60);
+  if (m === 0) return `${h}h`;
+  return `${h}h ${m}min`;
 }

--- a/src/app/components/reports/HoursTable.tsx
+++ b/src/app/components/reports/HoursTable.tsx
@@ -1,0 +1,140 @@
+import { useState } from "react";
+import { ChevronDown, ChevronUp, Clock, Pencil, Trash2 } from "lucide-react";
+
+export function HoursTable({ data }: { data: any[] }) {
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+
+  if (data.length === 0) {
+    return (
+      <div className="text-center text-[#6b7280] py-10">
+        Nenhum registro de horas encontrado.
+      </div>
+    );
+  }
+
+  return (
+    <table className="w-full text-sm">
+      <thead className="bg-[#f9fafb] text-[#6b7280] border-b border-[#eef0f4]">
+        <tr>
+          <th className="px-4 py-3 text-left">Data</th>
+          <th className="px-4 py-3 text-left">Duração</th>
+          <th className="px-4 py-3 text-left">Descrição</th>
+          <th className="px-4 py-3 text-left">Status</th>
+          <th className="px-4 py-3 text-left">Ações</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        {data.map((item) => {
+          const status = item.status ?? "VALIDO";
+          const isExpanded = expandedId === item.id;
+
+          return (
+            <tr key={item.id} className="border-t border-[#eef0f4]">
+              <td className="px-4 py-3">
+                {new Date(item.startTime).toLocaleDateString("pt-BR")}
+              </td>
+
+              <td className="px-4 py-3">
+                <span className="inline-flex min-w-[120px] items-center justify-center gap-1.5 bg-blue-100 text-blue-600 px-2.5 py-1 rounded-full text-xs font-medium">
+                  <Clock size={13} strokeWidth={2} />
+                  {formatDuration(item.totalTimeSeconds)}
+                </span>
+              </td>
+
+              <td className="px-4 py-3 max-w-[430px]">
+                <div className="flex items-start gap-2">
+                  <span
+                    className={[
+                      "block text-[#111827]",
+                      isExpanded
+                        ? "whitespace-normal leading-relaxed"
+                        : "truncate max-w-[360px]",
+                    ].join(" ")}
+                  >
+                    {item.description}
+                  </span>
+
+                  <button
+                    type="button"
+                    onClick={() => setExpandedId(isExpanded ? null : item.id)}
+                    className="mt-[2px] text-[#6b7280] hover:text-[#3b5ccc] cursor-pointer"
+                    aria-label="Expandir descrição"
+                  >
+                    {isExpanded ? (
+                      <ChevronUp size={16} />
+                    ) : (
+                      <ChevronDown size={16} />
+                    )}
+                  </button>
+                </div>
+              </td>
+
+              <td className="px-4 py-3">
+                <span className={getStatusClass(status)}>
+                  {formatStatus(status)}
+                </span>
+              </td>
+
+              <td className="px-4 py-3">
+                <div className="flex items-center gap-3">
+                  <button
+                    type="button"
+                    aria-label="Editar relatório"
+                    className="text-[#3b5ccc] hover:text-[#2443a8] transition-colors cursor-pointer"
+                  >
+                    <Pencil size={16} />
+                  </button>
+
+                  <button
+                    type="button"
+                    aria-label="Excluir relatório"
+                    className="text-red-500 hover:text-red-700 transition-colors cursor-pointer"
+                  >
+                    <Trash2 size={16} />
+                  </button>
+                </div>
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}
+
+function formatDuration(seconds: number) {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+
+  return `${h}h ${m}min ${s}seg`;
+}
+
+function formatStatus(status: string) {
+  switch (status) {
+    case "VALIDO":
+      return "Válido";
+    case "INVALIDO":
+      return "Inválido";
+    case "REQUISITADO":
+      return "Requisitado";
+    default:
+      return "Válido";
+  }
+}
+
+function getStatusClass(status: string) {
+  const base = "px-2 py-1 rounded-full text-xs font-medium";
+
+  switch (status) {
+    case "VALIDO":
+      return `${base} bg-green-100 text-green-600`;
+    case "INVALIDO":
+      return `${base} bg-red-100 text-red-600`;
+    case "REQUISITADO":
+      return `${base} bg-orange-100 text-orange-600`;
+    default:
+      return `${base} bg-green-100 text-green-600`;
+  }
+}

--- a/src/app/components/reports/HoursTable.tsx
+++ b/src/app/components/reports/HoursTable.tsx
@@ -1,7 +1,21 @@
 import { useState } from "react";
 import { ChevronDown, ChevronUp, Clock, Pencil, Trash2 } from "lucide-react";
 
-export function HoursTable({ data }: { data: any[] }) {
+type HourStatus = "VALIDO" | "INVALIDO" | "REQUISITADO";
+
+interface HourEntry {
+  id: number;
+  startTime: string;
+  totalTimeSeconds: number;
+  description: string;
+  status?: HourStatus;
+}
+
+interface HoursTableProps {
+  data: HourEntry[];
+}
+
+export function HoursTable({ data }: HoursTableProps) {
   const [expandedId, setExpandedId] = useState<number | null>(null);
 
   if (data.length === 0) {
@@ -13,93 +27,99 @@ export function HoursTable({ data }: { data: any[] }) {
   }
 
   return (
-    <table className="w-full text-sm">
-      <thead className="bg-[#f9fafb] text-[#6b7280] border-b border-[#eef0f4]">
-        <tr>
-          <th className="px-4 py-3 text-left">Data</th>
-          <th className="px-4 py-3 text-left">Duração</th>
-          <th className="px-4 py-3 text-left">Descrição</th>
-          <th className="px-4 py-3 text-left">Status</th>
-          <th className="px-4 py-3 text-left">Ações</th>
-        </tr>
-      </thead>
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead className="bg-[#f9fafb] text-[#6b7280] border-b border-[#eef0f4]">
+          <tr>
+            <th className="px-4 py-3 text-left">Data</th>
+            <th className="px-4 py-3 text-left">Duração</th>
+            <th className="px-4 py-3 text-left">Descrição</th>
+            <th className="px-4 py-3 text-left">Status</th>
+            <th className="px-4 py-3 text-left">Ações</th>
+          </tr>
+        </thead>
 
-      <tbody>
-        {data.map((item) => {
-          const status = item.status ?? "VALIDO";
-          const isExpanded = expandedId === item.id;
+        <tbody>
+          {data.map((item) => {
+            const status: HourStatus = item.status ?? "VALIDO";
+            const isExpanded = expandedId === item.id;
 
-          return (
-            <tr key={item.id} className="border-t border-[#eef0f4]">
-              <td className="px-4 py-3">
-                {new Date(item.startTime).toLocaleDateString("pt-BR")}
-              </td>
+            return (
+              <tr key={item.id} className="border-t border-[#eef0f4]">
+                <td className="px-4 py-3">
+                  {new Date(item.startTime).toLocaleDateString("pt-BR")}
+                </td>
 
-              <td className="px-4 py-3">
-                <span className="inline-flex min-w-[120px] items-center justify-center gap-1.5 bg-blue-100 text-blue-600 px-2.5 py-1 rounded-full text-xs font-medium">
-                  <Clock size={13} strokeWidth={2} />
-                  {formatDuration(item.totalTimeSeconds)}
-                </span>
-              </td>
-
-              <td className="px-4 py-3 max-w-[430px]">
-                <div className="flex items-start gap-2">
-                  <span
-                    className={[
-                      "block text-[#111827]",
-                      isExpanded
-                        ? "whitespace-normal leading-relaxed"
-                        : "truncate max-w-[360px]",
-                    ].join(" ")}
-                  >
-                    {item.description}
+                <td className="px-4 py-3">
+                  <span className="inline-flex min-w-[120px] items-center justify-center gap-1.5 bg-blue-100 text-blue-600 px-2.5 py-1 rounded-full text-xs font-medium">
+                    <Clock size={13} strokeWidth={2} />
+                    {formatDuration(item.totalTimeSeconds)}
                   </span>
+                </td>
 
-                  <button
-                    type="button"
-                    onClick={() => setExpandedId(isExpanded ? null : item.id)}
-                    className="mt-[2px] text-[#6b7280] hover:text-[#3b5ccc] cursor-pointer"
-                    aria-label="Expandir descrição"
-                  >
-                    {isExpanded ? (
-                      <ChevronUp size={16} />
-                    ) : (
-                      <ChevronDown size={16} />
-                    )}
-                  </button>
-                </div>
-              </td>
+                <td className="px-4 py-3 max-w-[430px]">
+                  <div className="flex items-start gap-2">
+                    <span
+                      className={[
+                        "block text-[#111827]",
+                        isExpanded
+                          ? "whitespace-normal leading-relaxed"
+                          : "truncate max-w-[360px]",
+                      ].join(" ")}
+                    >
+                      {item.description}
+                    </span>
 
-              <td className="px-4 py-3">
-                <span className={getStatusClass(status)}>
-                  {formatStatus(status)}
-                </span>
-              </td>
+                    <button
+                      type="button"
+                      onClick={() => setExpandedId(isExpanded ? null : item.id)}
+                      className="mt-[2px] text-[#6b7280] hover:text-[#3b5ccc] cursor-pointer"
+                      aria-label="Expandir descrição"
+                    >
+                      {isExpanded ? (
+                        <ChevronUp size={16} />
+                      ) : (
+                        <ChevronDown size={16} />
+                      )}
+                    </button>
+                  </div>
+                </td>
 
-              <td className="px-4 py-3">
-                <div className="flex items-center gap-3">
-                  <button
-                    type="button"
-                    aria-label="Editar relatório"
-                    className="text-[#3b5ccc] hover:text-[#2443a8] transition-colors cursor-pointer"
-                  >
-                    <Pencil size={16} />
-                  </button>
+                <td className="px-4 py-3">
+                  <span className={getStatusClass(status)}>
+                    {formatStatus(status)}
+                  </span>
+                </td>
 
-                  <button
-                    type="button"
-                    aria-label="Excluir relatório"
-                    className="text-red-500 hover:text-red-700 transition-colors cursor-pointer"
-                  >
-                    <Trash2 size={16} />
-                  </button>
-                </div>
-              </td>
-            </tr>
-          );
-        })}
-      </tbody>
-    </table>
+                <td className="px-4 py-3">
+                  <div className="flex items-center gap-3">
+                    <button
+                      type="button"
+                      disabled
+                      aria-label="Editar relatório"
+                      title="Em breve"
+                      className="text-[#3b5ccc] opacity-50 cursor-not-allowed"
+                    >
+                      <Pencil size={16} />
+                    </button>
+
+                    <button
+                      type="button"
+                      disabled
+                      aria-label="Excluir relatório"
+                      title="Em breve"
+                      className="text-red-500 opacity-50 cursor-not-allowed"
+                    >
+                      <Trash2 size={16} />
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
   );
 }
 
@@ -111,7 +131,7 @@ function formatDuration(seconds: number) {
   return `${h}h ${m}min ${s}seg`;
 }
 
-function formatStatus(status: string) {
+function formatStatus(status: HourStatus) {
   switch (status) {
     case "VALIDO":
       return "Válido";
@@ -124,7 +144,7 @@ function formatStatus(status: string) {
   }
 }
 
-function getStatusClass(status: string) {
+function getStatusClass(status: HourStatus) {
   const base = "px-2 py-1 rounded-full text-xs font-medium";
 
   switch (status) {

--- a/src/app/pages/RelatoriosPage.tsx
+++ b/src/app/pages/RelatoriosPage.tsx
@@ -6,6 +6,14 @@ import { HoursSummary } from "../components/reports/HoursSummary";
 
 type TabId = "horas" | "sprint" | "andamento" | "final";
 
+interface HourEntry {
+  id: number;
+  startTime: string;
+  totalTimeSeconds: number;
+  description: string;
+  status?: "VALIDO" | "INVALIDO" | "REQUISITADO";
+}
+
 interface Tab {
   id: TabId;
   label: string;
@@ -22,18 +30,34 @@ const TABS: Tab[] = [
 export default function RelatoriosPage() {
   const [activeTab, setActiveTab] = useState<TabId>("horas");
   const [selectedProject, setSelectedProject] = useState("");
-  const [hours, setHours] = useState([]);
+  const [hours, setHours] = useState<HourEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-  api
-    .get("/hours/me")
-    .then((data) => {
-      setHours(data as []);
-    })
-    .catch((error) => {
-      console.error("Erro ao buscar horas:", error);
-    });
-}, []);
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    api
+      .get<HourEntry[]>("/hours/me")
+      .then((data) => {
+        if (cancelled) return;
+        setHours(data ?? []);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        console.error("Erro ao buscar horas:", err);
+        setError("Não foi possível carregar os registros de horas.");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const currentTab = TABS.find((t) => t.id === activeTab)!;
 
@@ -118,8 +142,20 @@ export default function RelatoriosPage() {
         <div role="tabpanel" className="p-6">
           {activeTab === "horas" && (
             <>
-              <HoursSummary data={hours} />
-              <HoursTable data={hours} />
+              {loading && (
+                <div className="text-center text-[#6b7280] py-10">
+                  Carregando registros...
+                </div>
+              )}
+              {!loading && error && (
+                <div className="text-center text-red-600 py-10">{error}</div>
+              )}
+              {!loading && !error && (
+                <>
+                  <HoursSummary data={hours} />
+                  <HoursTable data={hours} />
+                </>
+              )}
             </>
           )}
         </div>

--- a/src/app/pages/RelatoriosPage.tsx
+++ b/src/app/pages/RelatoriosPage.tsx
@@ -1,5 +1,8 @@
-import { useState } from "react";
+import { api } from "../services/api";
+import { useEffect, useState } from "react";
 import { FileText, Download, ChevronDown } from "lucide-react";
+import { HoursTable } from "../components/reports/HoursTable";
+import { HoursSummary } from "../components/reports/HoursSummary";
 
 type TabId = "horas" | "sprint" | "andamento" | "final";
 
@@ -19,6 +22,18 @@ const TABS: Tab[] = [
 export default function RelatoriosPage() {
   const [activeTab, setActiveTab] = useState<TabId>("horas");
   const [selectedProject, setSelectedProject] = useState("");
+  const [hours, setHours] = useState([]);
+
+  useEffect(() => {
+  api
+    .get("/hours/me")
+    .then((data) => {
+      setHours(data as []);
+    })
+    .catch((error) => {
+      console.error("Erro ao buscar horas:", error);
+    });
+}, []);
 
   const currentTab = TABS.find((t) => t.id === activeTab)!;
 
@@ -100,7 +115,14 @@ export default function RelatoriosPage() {
         )}
 
         {/* Slot – cada aba renderiza seu componente filho */}
-        <div role="tabpanel" className="p-6" />
+        <div role="tabpanel" className="p-6">
+          {activeTab === "horas" && (
+            <>
+              <HoursSummary data={hours} />
+              <HoursTable data={hours} />
+            </>
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Foi implementada a aba de Relatórios de Horas com exibição dos registros do usuário em formato de tabela integrada ao backend por meio do endpoint GET /hours/me. A tabela apresenta as colunas de data, duração, descrição, status e ações. A duração é calculada a partir do campo totalTimeSeconds e exibida no formato de horas, minutos e segundos. A descrição dos registros é mostrada de forma truncada, com a possibilidade de expansão ao clicar na seta, alternando entre os estados aberto e fechado. Também foi implementado um banner de resumo exibindo as horas concluídas, o total de horas e as horas restantes para conclusão. O status é exibido por meio de badges coloridos, seguindo o padrão visual de válido, inválido e requisitado, sendo que atualmente parte desse comportamento está mockada devido à ausência de retorno completo pelo backend. Foram adicionados botões de ação com ícones de editar e excluir, sem integração funcional neste momento. Além disso, foi tratado o estado vazio para quando não houver registros e realizados ajustes visuais para melhorar a consistência, alinhamento e apresentação geral da interface.



<img width="1919" height="916" alt="Captura de tela 2026-05-01 184532" src="https://github.com/user-attachments/assets/c7515926-fb08-4ba7-ad06-ea4251d0e8ca" />
