### PR TITLE
[US002] Tela de recuperação de senha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "lucide-react": "^1.8.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-hot-toast": "^2.6.0",
         "react-router": "^7.13.0",
         "tailwindcss": "^4.2.2"
       },
@@ -1520,8 +1521,7 @@
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1659,6 +1659,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/goober": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.18.tgz",
+      "integrity": "sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
       }
     },
     "node_modules/graceful-fs": {
@@ -2083,6 +2092,23 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
+      "integrity": "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-refresh": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lucide-react": "^1.8.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-hot-toast": "^2.6.0",
     "react-router": "^7.13.0",
     "tailwindcss": "^4.2.2"
   },

--- a/src/app/components/passwordRecovery/PasswordRecovery.tsx
+++ b/src/app/components/passwordRecovery/PasswordRecovery.tsx
@@ -1,0 +1,115 @@
+import React, { useState, useEffect } from 'react';
+import { InputField } from "../ui/InputField/InputField";
+import { Button } from "../ui/Button/Button";
+import BackgroundImage from '../../assets/images/login/bg/bg-01.webp';
+import LogoFluxo from '../../assets/images/login/logo_fluxo_ages.webp';
+import toast, { Toaster } from 'react-hot-toast';
+
+const PasswordRecovery = () => {
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState('');
+  const [isFormValid, setIsFormValid] = useState(false);
+
+  useEffect(() => {
+    const passwordsMatch = password === confirmPassword;
+    const isNotEmpty = password.length > 0 && confirmPassword.length > 0;
+    setIsFormValid(passwordsMatch && isNotEmpty);
+
+    if (confirmPassword.length > 0 && !passwordsMatch) {
+      setError('As senhas não coincidem');
+    } else {
+      setError('');
+    }
+  }, [password, confirmPassword]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    if (isFormValid) {
+      toast.success(
+        (t) => (
+          <div className="flex items-center gap-4">
+            <div className="text-white text-2xl">✓</div>
+            <div className="flex flex-col">
+              <span className="font-bold text-white text-sm">Sucesso</span>
+              <span className="text-white text-xs">Senha alterada com sucesso!</span>
+            </div>
+          </div>
+        ),
+        {
+          duration: 4000,
+          position: 'top-right',
+          style: {
+            background: '#4CAF50', 
+            padding: '6px 10px',
+            borderRadius: '0px', 
+            maxWidth: '400px',
+          },
+          icon: null, 
+        }
+      );
+      
+      setPassword('');
+      setConfirmPassword('');
+    }
+  }; 
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-cover bg-center bg-no-repeat relative" 
+         style={{ backgroundImage: `url(${BackgroundImage})` }}>
+      
+      <Toaster position="top-right" />
+      
+      {/* Overlay de desfoque conforme critério de aceitação */}
+      <div className="absolute inset-0 bg-slate-900/40 backdrop-blur-sm"></div>
+      
+      {/* Container Branco com largura reduzida */}
+      <div className="bg-white p-8 rounded-xl shadow-2xl w-full max-w-sm flex flex-col items-center z-10">
+        
+        <img src={LogoFluxo} alt="FluxoAGES" className="mb-2 w-32" />
+        
+        <h2 className="text-gray-400 uppercase tracking-[0.2em] text-[9px] font-semibold mb-6">
+          Mudança de Senha
+        </h2>
+
+        <form onSubmit={handleSubmit} className="w-full space-y-4">
+          <InputField 
+            label="Nova Senha"
+            type="password"
+            name="password" 
+            value={password}
+            onChange={(val) => setPassword(val)}
+            placeholder="Digite sua senha"
+          />
+
+          <div className="space-y-1">
+            <InputField 
+              label="Confirmar Senha"
+              type="password"
+              name="confirmPassword" 
+              value={confirmPassword}
+              onChange={(val) => setConfirmPassword(val)}
+              placeholder="Digite sua senha"
+            />
+            {error && <span className="text-red-500 text-[10px] ml-1">{error}</span>}
+          </div>
+
+          <Button 
+            type="submit" 
+            disabled={!isFormValid}
+            className="w-full bg-[#3b59c8] hover:bg-[#2f48a3] text-white py-2.5 rounded-md font-medium transition-all disabled:opacity-50 disabled:cursor-not-allowed mt-4"
+          >
+            Confirmar
+          </Button>
+        </form>
+
+        <footer className="mt-8 text-[9px] text-gray-400 text-center">
+          © 2026 FluxoAGES - PUCRS · Todos os direitos reservados
+        </footer>
+      </div>
+    </div>
+  );
+};
+
+export default PasswordRecovery;

--- a/src/app/components/passwordRecovery/PasswordRecovery.tsx
+++ b/src/app/components/passwordRecovery/PasswordRecovery.tsx
@@ -1,102 +1,112 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect } from "react";
 import { InputField } from "../ui/InputField/InputField";
 import { Button } from "../ui/Button/Button";
-import BackgroundImage from '../../assets/images/login/bg/bg-01.webp';
-import LogoFluxo from '../../assets/images/login/logo_fluxo_ages.webp';
-import toast, { Toaster } from 'react-hot-toast';
+import BackgroundImage from "../../assets/images/login/bg/bg-01.webp";
+import LogoFluxo from "../../assets/images/login/logo_fluxo_ages.webp";
+import toast, { Toaster } from "react-hot-toast";
+
+const MIN_PASSWORD_LENGTH = 8;
 
 const PasswordRecovery = () => {
-  const [password, setPassword] = useState('');
-  const [confirmPassword, setConfirmPassword] = useState('');
-  const [error, setError] = useState('');
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [error, setError] = useState("");
   const [isFormValid, setIsFormValid] = useState(false);
 
   useEffect(() => {
-    const passwordsMatch = password === confirmPassword;
-    const isNotEmpty = password.length > 0 && confirmPassword.length > 0;
-    setIsFormValid(passwordsMatch && isNotEmpty);
+    const trimmedPassword = password.trim();
+    const trimmedConfirm = confirmPassword.trim();
+    const passwordsMatch = trimmedPassword === trimmedConfirm;
+    const meetsLength = trimmedPassword.length >= MIN_PASSWORD_LENGTH;
+    const isNotEmpty = trimmedPassword.length > 0 && trimmedConfirm.length > 0;
 
-    if (confirmPassword.length > 0 && !passwordsMatch) {
-      setError('As senhas não coincidem');
+    setIsFormValid(passwordsMatch && meetsLength && isNotEmpty);
+
+    if (trimmedPassword.length > 0 && !meetsLength) {
+      setError(`A senha deve ter pelo menos ${MIN_PASSWORD_LENGTH} caracteres`);
+    } else if (trimmedConfirm.length > 0 && !passwordsMatch) {
+      setError("As senhas não coincidem");
     } else {
-      setError('');
+      setError("");
     }
   }, [password, confirmPassword]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    
-    if (isFormValid) {
-      toast.success(
-        (t) => (
-          <div className="flex items-center gap-4">
-            <div className="text-white text-2xl">✓</div>
-            <div className="flex flex-col">
-              <span className="font-bold text-white text-sm">Sucesso</span>
-              <span className="text-white text-xs">Senha alterada com sucesso!</span>
-            </div>
+
+    if (!isFormValid) return;
+
+    toast.success(
+      () => (
+        <div className="flex items-center gap-4">
+          <div className="text-white text-2xl">✓</div>
+          <div className="flex flex-col">
+            <span className="font-bold text-white text-sm">Sucesso</span>
+            <span className="text-white text-xs">
+              Senha alterada com sucesso!
+            </span>
           </div>
-        ),
-        {
-          duration: 4000,
-          position: 'top-right',
-          style: {
-            background: '#4CAF50', 
-            padding: '6px 10px',
-            borderRadius: '0px', 
-            maxWidth: '400px',
-          },
-          icon: null, 
-        }
-      );
-      
-      setPassword('');
-      setConfirmPassword('');
-    }
-  }; 
+        </div>
+      ),
+      {
+        duration: 4000,
+        position: "top-right",
+        style: {
+          background: "#4CAF50",
+          padding: "6px 10px",
+          borderRadius: "0px",
+          maxWidth: "400px",
+        },
+        icon: null,
+      },
+    );
+
+    setPassword("");
+    setConfirmPassword("");
+  };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-cover bg-center bg-no-repeat relative" 
-         style={{ backgroundImage: `url(${BackgroundImage})` }}>
-      
+    <div
+      className="min-h-screen flex items-center justify-center bg-cover bg-center bg-no-repeat relative"
+      style={{ backgroundImage: `url(${BackgroundImage})` }}
+    >
       <Toaster position="top-right" />
-      
-      {/* Overlay de desfoque conforme critério de aceitação */}
+
       <div className="absolute inset-0 bg-slate-900/40 backdrop-blur-sm"></div>
-      
-      {/* Container Branco com largura reduzida */}
+
       <div className="bg-white p-8 rounded-xl shadow-2xl w-full max-w-sm flex flex-col items-center z-10">
-        
         <img src={LogoFluxo} alt="FluxoAGES" className="mb-2 w-32" />
-        
+
         <h2 className="text-gray-400 uppercase tracking-[0.2em] text-[9px] font-semibold mb-6">
           Mudança de Senha
         </h2>
 
         <form onSubmit={handleSubmit} className="w-full space-y-4">
-          <InputField 
+          <InputField
             label="Nova Senha"
             type="password"
-            name="password" 
+            name="password"
             value={password}
             onChange={(val) => setPassword(val)}
             placeholder="Digite sua senha"
           />
 
           <div className="space-y-1">
-            <InputField 
+            <InputField
               label="Confirmar Senha"
               type="password"
-              name="confirmPassword" 
+              name="confirmPassword"
               value={confirmPassword}
               onChange={(val) => setConfirmPassword(val)}
               placeholder="Digite sua senha"
             />
-            {error && <span className="text-red-500 text-[10px] ml-1">{error}</span>}
+            {error && (
+              <span className="text-red-500 text-[10px] ml-1">{error}</span>
+            )}
           </div>
 
-          <Button 
-            type="submit" 
+          <Button
+            type="submit"
             disabled={!isFormValid}
             className="w-full bg-[#3b59c8] hover:bg-[#2f48a3] text-white py-2.5 rounded-md font-medium transition-all disabled:opacity-50 disabled:cursor-not-allowed mt-4"
           >

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -3,9 +3,11 @@ import LoginPage from "./pages/LoginPage";
 import { AppLayout } from "./components/dashboard/AppLayout";
 import DashboardPage from "./pages/DashboardPage";
 import RelatoriosPage from "./pages/RelatoriosPage";
+import PasswordRecovery from "./components/passwordRecovery/PasswordRecovery";
 
 export const router = createBrowserRouter([
   { path: "/login", Component: LoginPage },
+  { path: "/recuperar-senha", Component: PasswordRecovery },
   {
     path: "/",
     Component: AppLayout,


### PR DESCRIPTION
Reabrindo o PR #51 após rebase em cima do dev atualizado e ajustes na validação.

## Mudanças
- Tela de recuperação de senha com validação de senha + confirmação
- Toast de sucesso usando react-hot-toast
- Rota `/recuperar-senha`

## Ajustes em cima do PR original
- Adiciona checagem de tamanho mínimo da senha (8 caracteres)
- Aplica trim na validação para não aceitar espaços puros
- Mensagem de erro específica quando senha é curta

Substitui #51 (que era do fork).