### PR TITLE
feat: aba de relatório de sprint e modal de relatório de sprint

### DIFF
--- a/src/app/components/reports/SprintReportModal.tsx
+++ b/src/app/components/reports/SprintReportModal.tsx
@@ -1,0 +1,159 @@
+import { useState } from "react";
+import { Modal } from "../ui/Modal/Modal";
+
+interface SprintReportModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function SprintReportModal({ isOpen, onClose }: SprintReportModalProps) {
+  const [project] = useState("Fluxo AGES 2.0 - Alunos");
+  const [sprint, setSprint] = useState("");
+  const [plannedActivities, setPlannedActivities] = useState("");
+  const [completedActivities, setCompletedActivities] = useState("");
+  const [problems, setProblems] = useState("");
+  const [lessonsLearned, setLessonsLearned] = useState("");
+  const [nextSteps, setNextSteps] = useState("");
+
+  const isFormValid =
+    sprint.trim() &&
+    plannedActivities.trim() &&
+    completedActivities.trim() &&
+    problems.trim() &&
+    lessonsLearned.trim() &&
+    nextSteps.trim();
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Relatório de Sprint">
+      <div className="mt-4 flex max-h-[70vh] flex-col">
+        <div className="flex flex-col gap-4 overflow-y-auto pr-2">
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="mb-1 block text-sm font-medium text-[#374151]">
+                Projeto*
+              </label>
+
+              <input
+                value={project}
+                disabled
+                className="
+                  h-[42px] w-full rounded-lg border border-[#e5e7eb]
+                  bg-[#f9fafb] px-3 text-sm text-[#6b7280]
+                "
+              />
+            </div>
+
+            <div>
+              <label className="mb-1 block text-sm font-medium text-[#374151]">
+                Sprint*
+              </label>
+
+              <select
+                value={sprint}
+                onChange={(e) => setSprint(e.target.value)}
+                className="
+                  h-[42px] w-full rounded-lg border border-[#e5e7eb]
+                  bg-white px-3 text-sm text-[#374151]
+                  focus:outline-none focus:ring-2 focus:ring-[#3b5ccc]/30
+                "
+              >
+                <option value="">Selecione</option>
+                <option value="Sprint 1">Sprint 1</option>
+                <option value="Sprint 2">Sprint 2</option>
+                <option value="Sprint 3">Sprint 3</option>
+                <option value="Sprint 4">Sprint 4</option>
+                <option value="Sprint 5">Sprint 5</option>
+              </select>
+            </div>
+          </div>
+
+          <TextAreaField
+            label="Atividades Previstas*"
+            value={plannedActivities}
+            onChange={setPlannedActivities}
+          />
+
+          <TextAreaField
+            label="Atividades Concluídas*"
+            value={completedActivities}
+            onChange={setCompletedActivities}
+          />
+
+          <TextAreaField
+            label="Problemas Encontrados*"
+            value={problems}
+            onChange={setProblems}
+          />
+
+          <TextAreaField
+            label="Lições Aprendidas*"
+            value={lessonsLearned}
+            onChange={setLessonsLearned}
+          />
+
+          <TextAreaField
+            label="Próximos Passos*"
+            value={nextSteps}
+            onChange={setNextSteps}
+          />
+        </div>
+
+        <div className="mt-4 flex justify-end gap-3 border-t border-[#e5e7eb] pt-4">
+          <button
+            type="button"
+            onClick={onClose}
+            className="
+              rounded-lg border border-[#e5e7eb]
+              px-5 py-2 text-sm font-medium text-[#374151]
+              hover:bg-[#f9fafb]
+              transition-colors cursor-pointer
+            "
+          >
+            Fechar
+          </button>
+
+          <button
+            type="button"
+            disabled={!isFormValid}
+            className="
+              rounded-lg bg-[#f97316]
+              px-5 py-2 text-sm font-medium text-white
+              hover:bg-[#ea580c]
+              disabled:cursor-not-allowed disabled:opacity-50
+            "
+          >
+            Cadastrar
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+interface TextAreaFieldProps {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+}
+
+function TextAreaField({ label, value, onChange }: TextAreaFieldProps) {
+  return (
+    <div>
+      <label className="mb-1 block text-sm font-medium text-[#374151]">
+        {label}
+      </label>
+
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        rows={4}
+        className="
+          w-full rounded-lg border border-[#e5e7eb]
+          px-3 py-2 text-sm text-[#374151]
+          resize-none
+          focus:outline-none focus:ring-2 focus:ring-[#3b5ccc]/30
+        "
+      />
+    </div>
+  );
+}

--- a/src/app/components/reports/SprintTable.tsx
+++ b/src/app/components/reports/SprintTable.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useState } from "react";
+import { LoaderCircle, Plus } from "lucide-react";
+import { SprintReportModal } from "./SprintReportModal";
+
+interface SprintReport {
+  id: number;
+  sprint: string;
+  student: string;
+  date: string;
+  status: "PROCESSANDO" | "ENVIADO";
+}
+
+export function SprintTable() {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const [sprintReports, setSprintReports] = useState<SprintReport[]>([
+    {
+      id: 1,
+      sprint: "Sprint 1",
+      student: "João Silva",
+      date: "2024-06-15T14:30:00Z",
+      status: "ENVIADO",
+    },
+    {
+      id: 2,
+      sprint: "Sprint 2",
+      student: "Maria Oliveira",
+      date: "2024-06-20T10:00:00Z",
+      status: "PROCESSANDO",
+    },
+  ]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setSprintReports((prev) =>
+        prev.map((report) =>
+          report.status === "PROCESSANDO"
+            ? { ...report, status: "ENVIADO" }
+            : report
+        )
+      );
+    }, 2000);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <>
+      <div className="mb-4 flex justify-end">
+        <button
+          type="button"
+          onClick={() => setIsModalOpen(true)}
+          className="inline-flex items-center gap-2 rounded-lg bg-[#3b5ccc] px-4 py-2 text-sm font-medium text-white hover:bg-[#2f4bb0] transition-colors cursor-pointer"
+        >
+          <Plus size={16} />
+          Novo Relatório
+        </button>
+      </div>
+
+      {sprintReports.length === 0 ? (
+        <div className="text-center text-[#6b7280] py-10">
+          Nenhum relatório de sprint encontrado.
+        </div>
+      ) : (
+        <table className="w-full text-sm">
+          <thead className="bg-[#f9fafb] text-[#6b7280] border-b border-[#eef0f4]">
+            <tr>
+              <th className="px-4 py-3 text-left">Sprint</th>
+              <th className="px-4 py-3 text-left">Aluno</th>
+              <th className="px-4 py-3 text-left">Data</th>
+              <th className="px-4 py-3 text-left">Status</th>
+            </tr>
+          </thead>
+
+          <tbody>
+            {sprintReports.map((item) => (
+              <tr key={item.id} className="border-t border-[#eef0f4]">
+                <td className="px-4 py-3 font-medium text-[#374151]">
+                  {item.sprint}
+                </td>
+
+                <td className="px-4 py-3 text-[#374151]">{item.student}</td>
+
+                <td className="px-4 py-3 text-[#374151]">
+                  {new Date(item.date).toLocaleDateString("pt-BR")}
+                </td>
+
+                <td className="px-4 py-3">
+                  {item.status === "PROCESSANDO" ? (
+                    <span className="inline-flex items-center gap-1.5 rounded-full bg-blue-100 px-2.5 py-1 text-xs font-medium text-blue-600">
+                      <LoaderCircle size={13} className="animate-spin" />
+                      Enviando
+                    </span>
+                  ) : (
+                    <span className="rounded-full bg-green-100 px-2.5 py-1 text-xs font-medium text-green-600">
+                      Enviado
+                    </span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      <SprintReportModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+      />
+    </>
+  );
+}

--- a/src/app/pages/RelatoriosPage.tsx
+++ b/src/app/pages/RelatoriosPage.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { FileText, Download, ChevronDown } from "lucide-react";
 import { HoursTable } from "../components/reports/HoursTable";
 import { HoursSummary } from "../components/reports/HoursSummary";
+import { SprintTable } from "../components/reports/SprintTable";
 
 type TabId = "horas" | "sprint" | "andamento" | "final";
 
@@ -158,6 +159,7 @@ export default function RelatoriosPage() {
               )}
             </>
           )}
+          {activeTab === "sprint" && <SprintTable />}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Acabei desenvolvendo as duas tasks dentro da mesma branch. Inicialmente foi realizada a implementação da tela de relatório de sprint, criando uma nova file dentro da pasta `reports`, onde está concentrada toda a lógica relacionada aos relatórios da aplicação. Nessa etapa foi estruturada a tabela responsável por exibir os relatórios de sprint, incluindo colunas de sprint, aluno, data e status, além da implementação visual dos badges e indicador de carregamento durante o envio do relatório.

Posteriormente, foi criada uma nova file responsável pelo modal de criação de relatório de sprint, utilizando o componente reutilizável de modal já existente no projeto. Dentro desse modal foram implementados os campos obrigatórios do formulário, incluindo dropdown de sprint, campos de texto e validação para habilitação do botão de cadastro apenas quando todos os campos estiverem preenchidos. Também foram realizados ajustes de usabilidade e layout, como scroll interno para os campos de escrita e fixação dos botões de ação na parte inferior do modal.


