### PR TITLE
fix: ajustando overflow da descrição para quebrar a linha mesmo quand…

### DIFF
--- a/src/app/components/reports/HoursTable.tsx
+++ b/src/app/components/reports/HoursTable.tsx
@@ -68,7 +68,7 @@ export function HoursTable({ data }: HoursTableProps) {
                 <td className="px-6 py-4 align-top">
                   <div className="flex items-start gap-2 w-full">
                     <p
-                      className={`text-slate-700 leading-relaxed break-words ${
+                      className={`text-slate-700 leading-relaxed break-all ${
                         isExpanded ? "whitespace-normal" : "line-clamp-1"
                       }`}
                     >


### PR DESCRIPTION
Troquei `break-words` por `break-all`
O break words não quebrava a linha enquanto a palavra não termina, então se os 1250 caracteres da descrição não tiverem um espaço no meio, da um overflow enorme.
<img width="1439" height="630" alt="image" src="https://github.com/user-attachments/assets/b371bf98-e6ac-4858-bdd7-f5946449e814" />

Com o break-all ele cuida melhor disso e o overflow não ocorre
<img width="1448" height="620" alt="image" src="https://github.com/user-attachments/assets/e4d84a25-c5dd-4977-9702-447cecc0f59d" />
