### PR TITLE
feat: integrate progress, final and sprint report tabs with backend

### DIFF
--- a/src/app/components/reports/SprintReportModal.tsx
+++ b/src/app/components/reports/SprintReportModal.tsx
@@ -4,7 +4,8 @@ import { Modal } from "../ui/Modal/Modal";
 interface SprintReportModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSubmit?: (data: SprintReportFormData) => void;
+  onSubmit?: (data: SprintReportFormData) => void | Promise<void>;
+  isSubmitting?: boolean;
 }
 
 export interface SprintReportFormData {
@@ -23,6 +24,7 @@ export function SprintReportModal({
   isOpen,
   onClose,
   onSubmit,
+  isSubmitting = false,
 }: SprintReportModalProps) {
   const [sprint, setSprint] = useState("");
   const [plannedActivities, setPlannedActivities] = useState("");
@@ -52,9 +54,8 @@ export function SprintReportModal({
   );
 
   const handleSubmit = () => {
-    if (!isFormValid) return;
+    if (!isFormValid || isSubmitting) return;
 
-    // TODO: integrar com endpoint real de relatório de sprint quando o backend estiver pronto
     onSubmit?.({
       project: DEFAULT_PROJECT,
       sprint,
@@ -64,8 +65,6 @@ export function SprintReportModal({
       lessonsLearned,
       nextSteps,
     });
-
-    onClose();
   };
 
   return (
@@ -147,10 +146,12 @@ export function SprintReportModal({
           <button
             type="button"
             onClick={onClose}
+            disabled={isSubmitting}
             className="
               rounded-lg border border-[#e5e7eb]
               px-5 py-2 text-sm font-medium text-[#374151]
               hover:bg-[#f9fafb]
+              disabled:cursor-not-allowed disabled:opacity-50
               transition-colors cursor-pointer
             "
           >
@@ -160,7 +161,7 @@ export function SprintReportModal({
           <button
             type="button"
             onClick={handleSubmit}
-            disabled={!isFormValid}
+            disabled={!isFormValid || isSubmitting}
             className="
               rounded-lg bg-[#f97316]
               px-5 py-2 text-sm font-medium text-white
@@ -168,7 +169,7 @@ export function SprintReportModal({
               disabled:cursor-not-allowed disabled:opacity-50
             "
           >
-            Cadastrar
+            {isSubmitting ? "Enviando..." : "Cadastrar"}
           </button>
         </div>
       </div>

--- a/src/app/components/reports/SprintTable.tsx
+++ b/src/app/components/reports/SprintTable.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
-import { LoaderCircle, Plus } from "lucide-react";
+import { Plus } from "lucide-react";
+import { api } from "../../services/api";
+import { useToast } from "../../context/ToastContext";
 import {
   SprintReportModal,
   type SprintReportFormData,
@@ -10,58 +12,81 @@ interface SprintReport {
   sprint: string;
   student: string;
   date: string;
-  status: "PROCESSANDO" | "ENVIADO";
+  id_project: number;
 }
 
-// TODO: trocar para chamada real quando o endpoint estiver pronto
-const MOCK_SPRINT_REPORTS: SprintReport[] = [
-  {
-    id: 1,
-    sprint: "Sprint 1",
-    student: "João Silva",
-    date: "2024-06-15T14:30:00Z",
-    status: "ENVIADO",
-  },
-  {
-    id: 2,
-    sprint: "Sprint 2",
-    student: "Maria Oliveira",
-    date: "2024-06-20T10:00:00Z",
-    status: "PROCESSANDO",
-  },
-];
+interface SprintReportPayload {
+  sprint: number;
+  predictedActivity: string;
+  activityCompleted: string;
+  problemsEncountered: string;
+  learnedLessons: string;
+  nextSteps: string;
+}
+
+function parseSprintNumber(value: string): number {
+  const match = value.match(/\d+/);
+  return match ? Number(match[0]) : NaN;
+}
+
+function toPayload(data: SprintReportFormData): SprintReportPayload {
+  return {
+    sprint: parseSprintNumber(data.sprint),
+    predictedActivity: data.plannedActivities,
+    activityCompleted: data.completedActivities,
+    problemsEncountered: data.problems,
+    learnedLessons: data.lessonsLearned,
+    nextSteps: data.nextSteps,
+  };
+}
 
 export function SprintTable() {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [sprintReports, setSprintReports] =
-    useState<SprintReport[]>(MOCK_SPRINT_REPORTS);
+  const [sprintReports, setSprintReports] = useState<SprintReport[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { showToast } = useToast();
+
+  const fetchReports = () => {
+    setLoading(true);
+    setError(null);
+    api
+      .get<SprintReport[]>("/report/me/sprint")
+      .then((data) => setSprintReports(data ?? []))
+      .catch((err) => {
+        console.error("Erro ao buscar relatórios de sprint:", err);
+        setError("Não foi possível carregar os relatórios de sprint.");
+      })
+      .finally(() => setLoading(false));
+  };
 
   useEffect(() => {
-    // Simula a finalização do envio dos relatórios em PROCESSANDO
-    const timer = setTimeout(() => {
-      setSprintReports((prev) =>
-        prev.map((report) =>
-          report.status === "PROCESSANDO"
-            ? { ...report, status: "ENVIADO" }
-            : report,
-        ),
-      );
-    }, 2000);
-
-    return () => clearTimeout(timer);
+    fetchReports();
   }, []);
 
-  const handleSubmit = (data: SprintReportFormData) => {
-    setSprintReports((prev) => [
-      ...prev,
-      {
-        id: prev.length > 0 ? Math.max(...prev.map((r) => r.id)) + 1 : 1,
-        sprint: data.sprint,
-        student: "Aluno Atual",
-        date: new Date().toISOString(),
-        status: "PROCESSANDO",
-      },
-    ]);
+  const handleSubmit = async (data: SprintReportFormData) => {
+    setIsSubmitting(true);
+    try {
+      await api.post("/report/sprint", toPayload(data));
+      showToast({
+        variant: "success",
+        title: "Relatório enviado",
+        message: "Relatório de sprint registrado com sucesso.",
+      });
+      setIsModalOpen(false);
+      fetchReports();
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Erro ao enviar relatório.";
+      showToast({
+        variant: "error",
+        title: "Erro ao enviar",
+        message,
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   return (
@@ -77,7 +102,13 @@ export function SprintTable() {
         </button>
       </div>
 
-      {sprintReports.length === 0 ? (
+      {loading ? (
+        <div className="text-center text-[#6b7280] py-10">
+          Carregando relatórios...
+        </div>
+      ) : error ? (
+        <div className="text-center text-red-600 py-10">{error}</div>
+      ) : sprintReports.length === 0 ? (
         <div className="text-center text-[#6b7280] py-10">
           Nenhum relatório de sprint encontrado.
         </div>
@@ -89,7 +120,6 @@ export function SprintTable() {
                 <th className="px-4 py-3 text-left">Sprint</th>
                 <th className="px-4 py-3 text-left">Aluno</th>
                 <th className="px-4 py-3 text-left">Data</th>
-                <th className="px-4 py-3 text-left">Status</th>
               </tr>
             </thead>
 
@@ -105,19 +135,6 @@ export function SprintTable() {
                   <td className="px-4 py-3 text-[#374151]">
                     {new Date(item.date).toLocaleDateString("pt-BR")}
                   </td>
-
-                  <td className="px-4 py-3">
-                    {item.status === "PROCESSANDO" ? (
-                      <span className="inline-flex items-center gap-1.5 rounded-full bg-blue-100 px-2.5 py-1 text-xs font-medium text-blue-600">
-                        <LoaderCircle size={13} className="animate-spin" />
-                        Enviando
-                      </span>
-                    ) : (
-                      <span className="rounded-full bg-green-100 px-2.5 py-1 text-xs font-medium text-green-600">
-                        Enviado
-                      </span>
-                    )}
-                  </td>
                 </tr>
               ))}
             </tbody>
@@ -129,6 +146,7 @@ export function SprintTable() {
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
         onSubmit={handleSubmit}
+        isSubmitting={isSubmitting}
       />
     </>
   );

--- a/src/app/pages/RelatoriosPage.tsx
+++ b/src/app/pages/RelatoriosPage.tsx
@@ -40,41 +40,22 @@ const TABS: Tab[] = [
   { id: "final", label: "Final", hasProjectFilter: false },
 ];
 
-const MOCK_PROGRESS_REPORTS: ReportEntry[] = [
-  {
-    date: "09/07/2026",
-    project: "Fluxo AGES 2.0",
-    grade: 9.0,
-    feedback: "",
-  },
-  {
-    date: "16/04/2015",
-    project: "Fluxo AGES 1.0",
-    grade: 10.0,
-    feedback: "",
-  },
-];
+interface ReportApiResponse {
+  date: string;
+  project: string;
+  grade: number;
+  feedback: string | null;
+}
 
-const MOCK_FINAL_REPORTS: ReportEntry[] = [
-  {
-    date: "09/07/2026",
-    project: "Fluxo AGES 2.0",
-    grade: 10.0,
-    feedback: "",
-  },
-  {
-    date: "23/11/2023",
-    project: "Projeto 2",
-    grade: 9.5,
-    feedback: "",
-  },
-  {
-    date: "16/04/2021",
-    project: "Projeto 1",
-    grade: 8.0,
-    feedback: "",
-  },
-];
+function toReportEntry(report: ReportApiResponse): ReportEntry {
+  const [year, month, day] = report.date.split("-");
+  return {
+    date: `${day}/${month}/${year}`,
+    project: report.project,
+    grade: report.grade,
+    feedback: report.feedback ?? "",
+  };
+}
 
 export default function RelatoriosPage() {
   const [activeTab, setActiveTab] = useState<TabId>("horas");
@@ -110,19 +91,41 @@ export default function RelatoriosPage() {
     }
 
     if (activeTab === "andamento") {
-      // TODO: trocar para chamada real quando o endpoint estiver pronto
       setLoading(true);
       setError(null);
-      setProgressReport(MOCK_PROGRESS_REPORTS);
-      setLoading(false);
+      api
+        .get<ReportApiResponse[]>("/report/me/progress")
+        .then((data) => {
+          if (cancelled) return;
+          setProgressReport((data ?? []).map(toReportEntry));
+        })
+        .catch((err) => {
+          if (cancelled) return;
+          console.error("Erro ao buscar relatórios de andamento:", err);
+          setError("Não foi possível carregar os relatórios de andamento.");
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false);
+        });
     }
 
     if (activeTab === "final") {
-      // TODO: trocar para chamada real quando o endpoint estiver pronto
       setLoading(true);
       setError(null);
-      setFinalReport(MOCK_FINAL_REPORTS);
-      setLoading(false);
+      api
+        .get<ReportApiResponse[]>("/report/me/final")
+        .then((data) => {
+          if (cancelled) return;
+          setFinalReport((data ?? []).map(toReportEntry));
+        })
+        .catch((err) => {
+          if (cancelled) return;
+          console.error("Erro ao buscar relatórios finais:", err);
+          setError("Não foi possível carregar os relatórios finais.");
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false);
+        });
     }
 
     return () => {


### PR DESCRIPTION
## Mudanças

Substituição dos dados mockados pelas chamadas reais nos endpoints já existentes do backend:

- **Aba Andamento**: \`GET /report/me/progress\` em \`RelatoriosPage.tsx\`
- **Aba Final**: \`GET /report/me/final\` em \`RelatoriosPage.tsx\`
- **Aba Sprint**: \`GET /report/me/sprint\` no mount + refetch após criação em \`SprintTable.tsx\`
- **Criação de Sprint**: \`POST /report/sprint\` no \`SprintTable.handleSubmit\`

## Ajustes adicionais

- Conversão de data ISO → BR (\`2026-07-09\` → \`09/07/2026\`)
- Mapeamento de campos PT→EN no payload do sprint (\`plannedActivities\` → \`predictedActivity\`, etc.)
- Extração do número do sprint (\`"Sprint 1"\` → \`1\`)
- Remoção da coluna \`status\` da tabela de sprint (POST é síncrono, não havia processamento real)
- \`SprintReportModal\` recebe \`isSubmitting\` e não fecha sozinho mais (quem controla é o \`SprintTable\` no sucesso)

## Dependência

Depende do PR do backend que adiciona \`id\` no \`SprintReportListResponseDto\` e amplia o range do sprint para 1-5.

## Como testar

1. Subir backend + banco
2. Abrir \`/relatorios\` → trocar entre as abas Andamento/Final/Sprint → verificar que carregam do backend
3. Aba Sprint → "Novo Relatório" → preencher → "Cadastrar" → verificar toast de sucesso + nova linha na tabela