### PR TITLE
fix: align sprint tab styling and rebuild sprint modal with design system

### DIFF
--- a/src/app/components/reports/SprintReportModal.tsx
+++ b/src/app/components/reports/SprintReportModal.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useState } from "react";
 import { Modal } from "../ui/Modal/Modal";
+import { Button } from "../ui/Button/Button";
+import { TextArea } from "../ui/TextArea/TextArea";
 
 interface SprintReportModalProps {
   isOpen: boolean;
   onClose: () => void;
   onSubmit?: (data: SprintReportFormData) => void | Promise<void>;
   isSubmitting?: boolean;
+  usedSprints?: string[];
 }
 
 export interface SprintReportFormData {
@@ -19,12 +22,20 @@ export interface SprintReportFormData {
 }
 
 const DEFAULT_PROJECT = "Fluxo AGES 2.0 - Alunos";
+const SPRINT_OPTIONS = [
+  "Sprint 1",
+  "Sprint 2",
+  "Sprint 3",
+  "Sprint 4",
+  "Sprint 5",
+];
 
 export function SprintReportModal({
   isOpen,
   onClose,
   onSubmit,
   isSubmitting = false,
+  usedSprints = [],
 }: SprintReportModalProps) {
   const [sprint, setSprint] = useState("");
   const [plannedActivities, setPlannedActivities] = useState("");
@@ -43,6 +54,9 @@ export function SprintReportModal({
       setNextSteps("");
     }
   }, [isOpen]);
+
+  const usedSet = new Set(usedSprints);
+  const availableSprints = SPRINT_OPTIONS.filter((s) => !usedSet.has(s));
 
   const isFormValid = Boolean(
     sprint.trim() &&
@@ -69,73 +83,82 @@ export function SprintReportModal({
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} title="Relatório de Sprint">
-      <div className="mt-4 flex max-h-[70vh] flex-col">
-        <div className="flex flex-col gap-4 overflow-y-auto pr-2">
+      <div className="mt-4 flex max-h-[70vh] w-[640px] max-w-full flex-col">
+        <div
+          className="
+            flex flex-col gap-4 overflow-y-auto pr-2
+            scrollbar-thin
+            [&::-webkit-scrollbar]:w-1.5
+            [&::-webkit-scrollbar-thumb]:bg-slate-200
+            [&::-webkit-scrollbar-thumb]:rounded-full
+            [&::-webkit-scrollbar-track]:bg-transparent
+            hover:[&::-webkit-scrollbar-thumb]:bg-slate-300
+          "
+        >
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="mb-1 block text-sm font-medium text-[#374151]">
+              <label className="mb-1.5 block text-sm font-semibold text-[#6B7280]">
                 Projeto*
               </label>
 
               <input
                 value={DEFAULT_PROJECT}
                 disabled
-                className="
-                  h-[42px] w-full rounded-lg border border-[#e5e7eb]
-                  bg-[#f9fafb] px-3 text-sm text-[#6b7280]
-                "
+                className="h-[42px] w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-sm text-slate-500"
               />
             </div>
 
             <div>
-              <label className="mb-1 block text-sm font-medium text-[#374151]">
+              <label className="mb-1.5 block text-sm font-semibold text-[#6B7280]">
                 Sprint*
               </label>
 
               <select
                 value={sprint}
                 onChange={(e) => setSprint(e.target.value)}
-                className="
-                  h-[42px] w-full rounded-lg border border-[#e5e7eb]
-                  bg-white px-3 text-sm text-[#374151]
-                  focus:outline-none focus:ring-2 focus:ring-[#3b5ccc]/30
-                "
+                className="h-[42px] w-full rounded-2xl border border-slate-200 bg-white px-4 text-sm text-slate-700 cursor-pointer focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
               >
                 <option value="">Selecione</option>
-                <option value="Sprint 1">Sprint 1</option>
-                <option value="Sprint 2">Sprint 2</option>
-                <option value="Sprint 3">Sprint 3</option>
-                <option value="Sprint 4">Sprint 4</option>
-                <option value="Sprint 5">Sprint 5</option>
+                {SPRINT_OPTIONS.map((s) => (
+                  <option key={s} value={s} disabled={usedSet.has(s)}>
+                    {s}
+                    {usedSet.has(s) ? " (já enviada)" : ""}
+                  </option>
+                ))}
               </select>
+              {availableSprints.length === 0 && (
+                <span className="mt-1 block text-xs text-slate-500">
+                  Todas as sprints já possuem relatório.
+                </span>
+              )}
             </div>
           </div>
 
-          <TextAreaField
+          <TextArea
             label="Atividades Previstas*"
             value={plannedActivities}
             onChange={setPlannedActivities}
           />
 
-          <TextAreaField
+          <TextArea
             label="Atividades Concluídas*"
             value={completedActivities}
             onChange={setCompletedActivities}
           />
 
-          <TextAreaField
+          <TextArea
             label="Problemas Encontrados*"
             value={problems}
             onChange={setProblems}
           />
 
-          <TextAreaField
+          <TextArea
             label="Lições Aprendidas*"
             value={lessonsLearned}
             onChange={setLessonsLearned}
           />
 
-          <TextAreaField
+          <TextArea
             label="Próximos Passos*"
             value={nextSteps}
             onChange={setNextSteps}
@@ -143,64 +166,20 @@ export function SprintReportModal({
         </div>
 
         <div className="mt-4 flex justify-end gap-3 border-t border-[#e5e7eb] pt-4">
-          <button
-            type="button"
-            onClick={onClose}
-            disabled={isSubmitting}
-            className="
-              rounded-lg border border-[#e5e7eb]
-              px-5 py-2 text-sm font-medium text-[#374151]
-              hover:bg-[#f9fafb]
-              disabled:cursor-not-allowed disabled:opacity-50
-              transition-colors cursor-pointer
-            "
-          >
-            Fechar
-          </button>
-
-          <button
-            type="button"
+          <Button
+            variant="primary"
             onClick={handleSubmit}
             disabled={!isFormValid || isSubmitting}
-            className="
-              rounded-lg bg-[#f97316]
-              px-5 py-2 text-sm font-medium text-white
-              hover:bg-[#ea580c]
-              disabled:cursor-not-allowed disabled:opacity-50
-            "
+            loading={isSubmitting}
           >
             {isSubmitting ? "Enviando..." : "Cadastrar"}
-          </button>
+          </Button>
+
+          <Button variant="secondary" onClick={onClose} disabled={isSubmitting}>
+            Fechar
+          </Button>
         </div>
       </div>
     </Modal>
-  );
-}
-
-interface TextAreaFieldProps {
-  label: string;
-  value: string;
-  onChange: (value: string) => void;
-}
-
-function TextAreaField({ label, value, onChange }: TextAreaFieldProps) {
-  return (
-    <div>
-      <label className="mb-1 block text-sm font-medium text-[#374151]">
-        {label}
-      </label>
-
-      <textarea
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        rows={4}
-        className="
-          w-full rounded-lg border border-[#e5e7eb]
-          px-3 py-2 text-sm text-[#374151]
-          resize-none
-          focus:outline-none focus:ring-2 focus:ring-[#3b5ccc]/30
-        "
-      />
-    </div>
   );
 }

--- a/src/app/components/reports/SprintTable.tsx
+++ b/src/app/components/reports/SprintTable.tsx
@@ -7,7 +7,7 @@ import {
   type SprintReportFormData,
 } from "./SprintReportModal";
 
-interface SprintReport {
+export interface SprintReport {
   id: number;
   sprint: string;
   student: string;
@@ -113,26 +113,29 @@ export function SprintTable() {
           Nenhum relatório de sprint encontrado.
         </div>
       ) : (
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm">
+        <div className="w-full overflow-hidden rounded-xl border border-[#eef0f4]">
+          <table className="w-full text-sm border-collapse">
             <thead className="bg-[#f9fafb] text-[#6b7280] border-b border-[#eef0f4]">
               <tr>
-                <th className="px-4 py-3 text-left">Sprint</th>
-                <th className="px-4 py-3 text-left">Aluno</th>
-                <th className="px-4 py-3 text-left">Data</th>
+                <th className="px-6 py-4 text-left font-semibold">Sprint</th>
+                <th className="px-6 py-4 text-left font-semibold">Aluno</th>
+                <th className="px-6 py-4 text-left font-semibold">Data</th>
               </tr>
             </thead>
 
-            <tbody>
+            <tbody className="bg-white">
               {sprintReports.map((item) => (
-                <tr key={item.id} className="border-t border-[#eef0f4]">
-                  <td className="px-4 py-3 font-medium text-[#374151]">
+                <tr
+                  key={item.id}
+                  className="border-b border-[#eef0f4] hover:bg-slate-50/30 transition-colors last:border-b-0"
+                >
+                  <td className="px-6 py-4 font-medium text-slate-700">
                     {item.sprint}
                   </td>
 
-                  <td className="px-4 py-3 text-[#374151]">{item.student}</td>
+                  <td className="px-6 py-4 text-slate-600">{item.student}</td>
 
-                  <td className="px-4 py-3 text-[#374151]">
+                  <td className="px-6 py-4 text-slate-600">
                     {new Date(item.date).toLocaleDateString("pt-BR")}
                   </td>
                 </tr>
@@ -147,6 +150,7 @@ export function SprintTable() {
         onClose={() => setIsModalOpen(false)}
         onSubmit={handleSubmit}
         isSubmitting={isSubmitting}
+        usedSprints={sprintReports.map((r) => r.sprint)}
       />
     </>
   );

--- a/src/app/components/ui/Modal/Modal.tsx
+++ b/src/app/components/ui/Modal/Modal.tsx
@@ -87,8 +87,9 @@ export function Modal({
     >
       <div
         ref={modalRef}
-        className="bg-white p-6 rounded-xl min-w-[420px] z-[10000] border-l-4 border-blue-500 shadow-2xl"
+        className="relative bg-white p-6 rounded-xl min-w-[420px] z-[10000] shadow-2xl overflow-hidden"
       >
+        <div className="absolute top-0 left-0 right-0 h-0.5 bg-gradient-to-r from-[#3b5ccc] to-[#5b7ae8] z-10 rounded-t-xl" />
         <div className="flex justify-between items-center">
           <h2 className="text-[24px] font-bold text-black">{title}</h2>
           <div className="flex items-center gap-2">

--- a/src/app/pages/RelatoriosPage.tsx
+++ b/src/app/pages/RelatoriosPage.tsx
@@ -180,9 +180,9 @@ export default function RelatoriosPage() {
       </div>
 
       {/* Card container */}
-      <div className="bg-white rounded-2xl border border-[#e5e7eb] overflow-hidden">
+      <div className="bg-white rounded-2xl border border-[#e5e7eb]">
         {/* Barra de abas */}
-        <div className="flex items-center border-b border-[#e5e7eb] px-6">
+        <div className="sticky top-0 z-10 flex items-center border-b border-[#e5e7eb] px-6 bg-white rounded-t-2xl">
           <nav className="flex flex-1 gap-1" role="tablist">
             {TABS.map((tab) => {
               const isActive = tab.id === activeTab;

--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -1,5 +1,12 @@
 const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8081";
 
+function handleUnauthorized() {
+  localStorage.removeItem("token");
+  if (window.location.pathname !== "/login") {
+    window.location.replace("/login");
+  }
+}
+
 async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
   const token = localStorage.getItem("token");
   const headers: Record<string, string> = {
@@ -9,6 +16,11 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
   if (token) headers["Authorization"] = `Bearer ${token}`;
 
   const res = await fetch(`${BASE_URL}${path}`, { ...options, headers });
+
+  if (res.status === 401 && token) {
+    handleUnauthorized();
+    throw new Error("Sessão expirada. Faça login novamente.");
+  }
 
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));


### PR DESCRIPTION
## Mudanças

Aplicando o feedback de UX/UI na aba de Sprint e em pontos relacionados.

### Aba Sprint (listagem)
- Tabela agora usa o mesmo padrão visual do \`HoursTable\` e \`GenericReportsTable\` (border-rounded, paddings, cores de hover)

### Modal de Relatório de Sprint
- Usa o componente \`Button\` do projeto (variantes primary/secondary) ao invés de \`<button>\` cru
- Usa o componente \`TextArea\` do projeto ao invés de \`<textarea>\` cru
- Ordem dos botões invertida (Cadastrar antes de Fechar) pra bater com o Figma
- Validação: sprints já cadastradas ficam disabled no select com label "(já enviada)"; quando todas estão cadastradas mostra mensagem

### Modal base
- Removida a barra azul lateral (\`border-l-4 border-blue-500\`) que aparecia em todos os modais
- Substituída por uma faixa gradient no topo, consistente com o componente \`Card\`

### RelatoriosPage
- Barra de abas agora é \`sticky top-0\` — quando a lista de horas cresce e gera scroll, as abas continuam visíveis

### Api service
- \`request\` agora trata 401 globalmente: limpa o token do localStorage e redireciona pra \`/login\`
- Resolve o cenário em que o token expira em uso e o usuário fica preso na tela atual

## Como testar

1. Aba Sprint → criar relatório → verificar que a sprint criada fica disabled no próximo "Novo Relatório"
2. Modal de Sprint → conferir que botões e textareas usam o estilo padrão do projeto
3. Aba Horas → adicionar muitos registros → verificar que a barra de abas fica fixa no topo ao rolar
4. Invalidar manualmente o token no localStorage e fazer uma ação → deve redirecionar pra login