### PR TITLE
feat/flu-113-us027-frontend-modal-de-feedback-do-professor-nos-relatorios

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,17 +1,10 @@
 import { RouterProvider } from "react-router";
 import { router } from "./routes";
 import { Toaster } from "react-hot-toast";
-import { TeacherFeedbackModal } from "./components/reports/TeacherFeedbackModal"; // 1. Adicione o import
 
 export default function App() {
   return (
     <>
-    <TeacherFeedbackModal 
-        isOpen={true} // Força ele a ficar aberto na tela sem precisar logar
-        onClose={() => console.log("Fechando...")} 
-        reportData={{
-           }}
-      />
       <Toaster position="top-right" containerStyle={{ zIndex: 99999 }} />
       <RouterProvider router={router} />
     </>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,10 +1,17 @@
 import { RouterProvider } from "react-router";
 import { router } from "./routes";
 import { Toaster } from "react-hot-toast";
+import { TeacherFeedbackModal } from "./components/reports/TeacherFeedbackModal"; // 1. Adicione o import
 
 export default function App() {
   return (
     <>
+    <TeacherFeedbackModal 
+        isOpen={true} // Força ele a ficar aberto na tela sem precisar logar
+        onClose={() => console.log("Fechando...")} 
+        reportData={{
+           }}
+      />
       <Toaster position="top-right" containerStyle={{ zIndex: 99999 }} />
       <RouterProvider router={router} />
     </>

--- a/src/app/components/reports/GenericReportsTable.tsx
+++ b/src/app/components/reports/GenericReportsTable.tsx
@@ -1,4 +1,6 @@
+import { useState } from "react";
 import { Download, MessageSquare } from "lucide-react";
+import { TeacherFeedbackModal } from "./TeacherFeedbackModal";
 
 export interface ReportEntry {
   date: string;
@@ -12,7 +14,10 @@ interface GenericReportsTableProps {
 }
 
 export function GenericReportsTable({ data }: GenericReportsTableProps) {
-  if (data.length === 0) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedReport, setSelectedReport] = useState<ReportEntry | null>(null);
+  
+  if (!data || !Array.isArray(data) || data.length === 0) {
     return (
       <div className="text-center text-[#6b7280] py-10">
         Nenhum relatório encontrado.
@@ -65,12 +70,15 @@ export function GenericReportsTable({ data }: GenericReportsTableProps) {
                 {report.grade?.toFixed(1) ?? "-"}
               </td>
 
-              <td className="px-6 py-4 text-center">
+             <td className="px-6 py-4 text-center">
                 <button
                   type="button"
-                  disabled
-                  title="Em breve"
-                  className="text-[#3b5ccc] opacity-50 cursor-not-allowed"
+                  title="Ver feedback"
+                  onClick={() => {
+                    setSelectedReport(report);
+                    setIsModalOpen(true);
+                  }}
+                  className="text-[#3b5ccc] hover:text-[#2a459c] transition-colors"
                 >
                   <MessageSquare size={20} />
                 </button>
@@ -79,9 +87,9 @@ export function GenericReportsTable({ data }: GenericReportsTableProps) {
               <td className="px-6 py-4 text-center">
                 <button
                   type="button"
-                  disabled
-                  title="Em breve"
-                  className="text-[#3b5ccc] opacity-50 cursor-not-allowed"
+                  title="Baixar correção"
+                  onClick={() => alert("Download da correção iniciado!")}
+                  className="text-[#3b5ccc] hover:text-[#2a459c] transition-colors"
                 >
                   <Download size={20} />
                 </button>
@@ -90,6 +98,12 @@ export function GenericReportsTable({ data }: GenericReportsTableProps) {
           ))}
         </tbody>
       </table>
+    
+      <TeacherFeedbackModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        reportData={selectedReport}
+      />
     </div>
   );
 }

--- a/src/app/components/reports/GenericReportsTable.tsx
+++ b/src/app/components/reports/GenericReportsTable.tsx
@@ -15,8 +15,10 @@ interface GenericReportsTableProps {
 
 export function GenericReportsTable({ data }: GenericReportsTableProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [selectedReport, setSelectedReport] = useState<ReportEntry | null>(null);
-  
+  const [selectedReport, setSelectedReport] = useState<ReportEntry | null>(
+    null,
+  );
+
   if (!data || !Array.isArray(data) || data.length === 0) {
     return (
       <div className="text-center text-[#6b7280] py-10">
@@ -70,7 +72,7 @@ export function GenericReportsTable({ data }: GenericReportsTableProps) {
                 {report.grade?.toFixed(1) ?? "-"}
               </td>
 
-             <td className="px-6 py-4 text-center">
+              <td className="px-6 py-4 text-center">
                 <button
                   type="button"
                   title="Ver feedback"
@@ -87,9 +89,9 @@ export function GenericReportsTable({ data }: GenericReportsTableProps) {
               <td className="px-6 py-4 text-center">
                 <button
                   type="button"
-                  title="Baixar correção"
-                  onClick={() => alert("Download da correção iniciado!")}
-                  className="text-[#3b5ccc] hover:text-[#2a459c] transition-colors"
+                  disabled
+                  title="Em breve"
+                  className="text-[#3b5ccc] opacity-50 cursor-not-allowed"
                 >
                   <Download size={20} />
                 </button>
@@ -98,7 +100,7 @@ export function GenericReportsTable({ data }: GenericReportsTableProps) {
           ))}
         </tbody>
       </table>
-    
+
       <TeacherFeedbackModal
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}

--- a/src/app/components/reports/TeacherFeedbackModal.tsx
+++ b/src/app/components/reports/TeacherFeedbackModal.tsx
@@ -1,0 +1,56 @@
+import { Modal } from "../ui/Modal/Modal"; 
+
+interface TeacherFeedbackModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  reportData: {
+    feedback: string;
+  } | null;
+}
+
+export function TeacherFeedbackModal({ isOpen, onClose, reportData }: TeacherFeedbackModalProps) {
+  if (!reportData) return null;
+
+  const mockTeacher = {
+    name: "Dilnei Venturini", 
+  };
+
+  const mockLoremIpsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras non leo et neque scelerisque malesuada. Duis et laoreet enim, a venenatis tortor. Ut congue urna eros. Nullam sagittis augue nec lacinia sollicitudin. Phasellus mattis enim in purus iaculis convallis. Duis tincidunt nisi quis urna suscipit, vel consectetur dui aliquet. Aenean aliquam magna quis urna commodo, ac lobortis neque mollis. Cras et sem nec quam auctor aliquet et eu odio. Vivamus aliquam tortor eu leo cursus placerat.\n\nMorbi tortor arcu, laoreet sed pulvinar at, tincidunt quis metus. Nam dignissim libero sed odio porta lacinia. Suspendisse sagittis nulla et vehicula commodo. Donec orci purus, malesuada sed auctor commodo, venenatis vitae nunc. Nullam venenatis accumsan tortor a maximus. Proin vitae velit ligula. Nam pharetra mi sed mattis accumsan. Curabitur ullamcorper neque non enim tempor, id placerat diam pretium. Suspendisse quis sapien nisi. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.\n\nDuis et interdum leo. Sed efficitur, quam in auctor gravida, augue nisl lobortis nunc, in scelerisque ante nisi at leo. Cras ante tellus, aliquet et facilisis id, ornare vitae ligula. Suspendisse auctor, sapien sit amet imperdiet mattis, nisi sapien semper erat, vitae tempor enim purus id tellus. In eu est ut massa mollis placenta ut a sem. Pellentesque eu aliquam eros. Nulla et tortor mollis, commodo justo.";
+
+  return (
+    <Modal 
+      isOpen={isOpen} 
+      onClose={onClose} 
+      title="" 
+      className="max-w-[500px] [&_>_div:first-child]:from-[#ff7a00] [&_>_div:first-child]:to-[#ff9933]" 
+    >
+      <div className="-mt-6 text-[#374151]">
+        
+        <div className="border-b border-gray-100 pb-3 mb-4 pr-6">
+          <h3 className="text-[22px] font-bold text-[#1f2937] leading-tight">
+            Feedback do professor
+          </h3>
+          <p className="text-[14px] text-gray-400 mt-0.5">
+            {mockTeacher.name}
+          </p>
+        </div>
+
+        {/* Seção de Comentário */}
+        <div className="mb-2">
+          <h4 className="text-[14px] font-medium text-gray-500 mb-2">Comentário</h4>
+          
+          <div className="max-h-[360px] overflow-y-auto border border-gray-200 rounded-xl p-4 bg-white text-[14px] text-gray-600 leading-relaxed whitespace-pre-line
+            [&::-webkit-scrollbar]:w-1.5
+            [&::-webkit-scrollbar-track]:bg-transparent
+            [&::-webkit-scrollbar-thumb]:bg-gray-200
+            [&::-webkit-scrollbar-thumb]:rounded-full
+            hover:[&::-webkit-scrollbar-thumb]:bg-gray-300
+            [&::-webkit-scrollbar-button]:hidden"
+          >
+            {reportData.feedback || mockLoremIpsum}
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/app/components/reports/TeacherFeedbackModal.tsx
+++ b/src/app/components/reports/TeacherFeedbackModal.tsx
@@ -1,4 +1,4 @@
-import { Modal } from "../ui/Modal/Modal"; 
+import { Modal } from "../ui/Modal/Modal";
 
 interface TeacherFeedbackModalProps {
   isOpen: boolean;
@@ -8,38 +8,40 @@ interface TeacherFeedbackModalProps {
   } | null;
 }
 
-export function TeacherFeedbackModal({ isOpen, onClose, reportData }: TeacherFeedbackModalProps) {
+export function TeacherFeedbackModal({
+  isOpen,
+  onClose,
+  reportData,
+}: TeacherFeedbackModalProps) {
   if (!reportData) return null;
 
   const mockTeacher = {
-    name: "Dilnei Venturini", 
+    name: "Dilnei Venturini",
   };
 
-  const mockLoremIpsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras non leo et neque scelerisque malesuada. Duis et laoreet enim, a venenatis tortor. Ut congue urna eros. Nullam sagittis augue nec lacinia sollicitudin. Phasellus mattis enim in purus iaculis convallis. Duis tincidunt nisi quis urna suscipit, vel consectetur dui aliquet. Aenean aliquam magna quis urna commodo, ac lobortis neque mollis. Cras et sem nec quam auctor aliquet et eu odio. Vivamus aliquam tortor eu leo cursus placerat.\n\nMorbi tortor arcu, laoreet sed pulvinar at, tincidunt quis metus. Nam dignissim libero sed odio porta lacinia. Suspendisse sagittis nulla et vehicula commodo. Donec orci purus, malesuada sed auctor commodo, venenatis vitae nunc. Nullam venenatis accumsan tortor a maximus. Proin vitae velit ligula. Nam pharetra mi sed mattis accumsan. Curabitur ullamcorper neque non enim tempor, id placerat diam pretium. Suspendisse quis sapien nisi. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.\n\nDuis et interdum leo. Sed efficitur, quam in auctor gravida, augue nisl lobortis nunc, in scelerisque ante nisi at leo. Cras ante tellus, aliquet et facilisis id, ornare vitae ligula. Suspendisse auctor, sapien sit amet imperdiet mattis, nisi sapien semper erat, vitae tempor enim purus id tellus. In eu est ut massa mollis placenta ut a sem. Pellentesque eu aliquam eros. Nulla et tortor mollis, commodo justo.";
+  const mockLoremIpsum =
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras non leo et neque scelerisque malesuada. Duis et laoreet enim, a venenatis tortor. Ut congue urna eros. Nullam sagittis augue nec lacinia sollicitudin. Phasellus mattis enim in purus iaculis convallis. Duis tincidunt nisi quis urna suscipit, vel consectetur dui aliquet. Aenean aliquam magna quis urna commodo, ac lobortis neque mollis. Cras et sem nec quam auctor aliquet et eu odio. Vivamus aliquam tortor eu leo cursus placerat.\n\nMorbi tortor arcu, laoreet sed pulvinar at, tincidunt quis metus. Nam dignissim libero sed odio porta lacinia. Suspendisse sagittis nulla et vehicula commodo. Donec orci purus, malesuada sed auctor commodo, venenatis vitae nunc. Nullam venenatis accumsan tortor a maximus. Proin vitae velit ligula. Nam pharetra mi sed mattis accumsan. Curabitur ullamcorper neque non enim tempor, id placerat diam pretium. Suspendisse quis sapien nisi. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.\n\nDuis et interdum leo. Sed efficitur, quam in auctor gravida, augue nisl lobortis nunc, in scelerisque ante nisi at leo. Cras ante tellus, aliquet et facilisis id, ornare vitae ligula. Suspendisse auctor, sapien sit amet imperdiet mattis, nisi sapien semper erat, vitae tempor enim purus id tellus. In eu est ut massa mollis placenta ut a sem. Pellentesque eu aliquam eros. Nulla et tortor mollis, commodo justo.";
 
   return (
-    <Modal 
-      isOpen={isOpen} 
-      onClose={onClose} 
-      title="" 
-      className="max-w-[500px] [&_>_div:first-child]:from-[#ff7a00] [&_>_div:first-child]:to-[#ff9933]" 
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Feedback do professor"
+      className="max-w-[500px]"
     >
-      <div className="-mt-6 text-[#374151]">
-        
-        <div className="border-b border-gray-100 pb-3 mb-4 pr-6">
-          <h3 className="text-[22px] font-bold text-[#1f2937] leading-tight">
-            Feedback do professor
-          </h3>
-          <p className="text-[14px] text-gray-400 mt-0.5">
-            {mockTeacher.name}
-          </p>
-        </div>
+      <div className="text-[#374151]">
+        <p className="text-[14px] text-gray-400 border-b border-gray-100 pb-3 mb-4">
+          {mockTeacher.name}
+        </p>
 
         {/* Seção de Comentário */}
         <div className="mb-2">
-          <h4 className="text-[14px] font-medium text-gray-500 mb-2">Comentário</h4>
-          
-          <div className="max-h-[360px] overflow-y-auto border border-gray-200 rounded-xl p-4 bg-white text-[14px] text-gray-600 leading-relaxed whitespace-pre-line
+          <h4 className="text-[14px] font-medium text-gray-500 mb-2">
+            Comentário
+          </h4>
+
+          <div
+            className="max-h-[360px] overflow-y-auto border border-gray-200 rounded-xl p-4 bg-white text-[14px] text-gray-600 leading-relaxed whitespace-pre-line
             [&::-webkit-scrollbar]:w-1.5
             [&::-webkit-scrollbar-track]:bg-transparent
             [&::-webkit-scrollbar-thumb]:bg-gray-200


### PR DESCRIPTION
Alterações feitas na GenericReportsTable.tsx
-Adicionados os estados isModalOpen e selectedReport com useState para gerenciar a abertura do modal e armazenar os dados da linha clicada.
-Removidos os atributos de bloqueio (disabled, opacity-50, cursor-not-allowed) dos botões de feedback e download.
-Configurado o clique do botão de mensagem para repassar o relatório selecionado e abrir o modal.
-Adicionado um alerta temporário no botão de download para indicar o disparo da ação.
-Incluída uma validação condicional com Array.isArray(data) no início do componente para evitar o erro data.map is not a function caso a propriedade recebida seja nula ou inválida.
-Acoplado o componente <TeacherFeedbackModal /> antes do fechamento da estrutura principal.

Modal de Feedback (TeacherFeedbackModal.tsx)
- Criada a interface TeacherFeedbackModalProps para receber os estados de controle (isOpen, onClose e reportData).
- Adicionado retorno nulo (return null) caso o objeto reportData não esteja presente.
- De acordo com os requisitos do Figma.