### PR TITLE
[US022] [Frontend] - Expansão de linha na tabela de Relatórios de Sprint

### DIFF
--- a/src/app/components/reports/SprintReportModal.tsx
+++ b/src/app/components/reports/SprintReportModal.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 import { Modal } from "../ui/Modal/Modal";
 import { Button } from "../ui/Button/Button";
 import { TextArea } from "../ui/TextArea/TextArea";
+import { Select } from "../ui/Select/Select";
+import { InputField } from "../ui/InputField/InputField";
 
 interface SprintReportModalProps {
   isOpen: boolean;
@@ -101,36 +103,27 @@ export function SprintReportModal({
           "
         >
           <div className="grid grid-cols-2 gap-4">
+            {
+            <InputField label="Projeto" disabled={true} value={DEFAULT_PROJECT} mandatory={true} />
+            }
             <div>
               <label className="mb-1.5 block text-sm font-semibold text-[#6B7280]">
-                Projeto*
+                Sprint<span className="text-[#f47b20]">*</span>
               </label>
 
-              <input
-                value={DEFAULT_PROJECT}
-                disabled
-                className="h-[42px] w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-sm text-slate-500"
-              />
-            </div>
-
-            <div>
-              <label className="mb-1.5 block text-sm font-semibold text-[#6B7280]">
-                Sprint*
-              </label>
-
-              <select
+              <Select
                 value={sprint}
                 onChange={(e) => setSprint(e.target.value)}
-                className="h-[42px] w-full rounded-2xl border border-slate-200 bg-white px-4 text-sm text-slate-700 cursor-pointer focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
-              >
-                <option value="">Selecione</option>
-                {SPRINT_OPTIONS.map((s) => (
-                  <option key={s} value={s} disabled={usedSet.has(s)}>
-                    {s}
-                    {usedSet.has(s) ? " (já enviada)" : ""}
-                  </option>
-                ))}
-              </select>
+                placeholder="Selecione"
+                wrapperClassName="w-full"
+                className="w-full h-[42px] rounded-2xl" 
+                options={SPRINT_OPTIONS.map((s) => ({
+                  value: s,
+                  label: usedSet.has(s) ? `${s} (já enviada)` : s,
+                  disabled: usedSet.has(s),
+                }))}
+              />
+              
               {availableSprints.length === 0 && (
                 <span className="mt-1 block text-xs text-slate-500">
                   Todas as sprints já possuem relatório.
@@ -140,50 +133,64 @@ export function SprintReportModal({
           </div>
 
           <TextArea
-            label="Atividades Previstas*"
+            label="Atividades Previstas"
             value={plannedActivities}
             onChange={setPlannedActivities}
+            mandatory={true}
           />
 
           <TextArea
-            label="Atividades Concluídas*"
+            label="Atividades Concluídas"
             value={completedActivities}
             onChange={setCompletedActivities}
+            mandatory={true}
           />
 
           <TextArea
-            label="Problemas Encontrados*"
+            label="Problemas Encontrados"
             value={problems}
             onChange={setProblems}
+            mandatory={true}
           />
 
           <TextArea
-            label="Lições Aprendidas*"
+            label="Lições Aprendidas"
             value={lessonsLearned}
             onChange={setLessonsLearned}
+            mandatory={true}
           />
 
           <TextArea
-            label="Próximos Passos*"
+            label="Próximos Passos"
             value={nextSteps}
             onChange={setNextSteps}
+            mandatory={true}
           />
         </div>
 
-        <div className="mt-4 flex justify-end gap-3 border-t border-[#e5e7eb] pt-4">
+        <div className="mt-8 flex items-center gap-4 w-full">
           <Button
             variant="primary"
+            fullWidth
             onClick={handleSubmit}
             disabled={!isFormValid || isSubmitting}
             loading={isSubmitting}
+            className="!bg-[#f47b20]"
           >
             {isSubmitting ? "Enviando..." : "Cadastrar"}
           </Button>
 
-          <Button variant="secondary" onClick={onClose} disabled={isSubmitting}>
+          <Button 
+            variant="secondary" 
+            fullWidth
+            onClick={onClose} 
+            disabled={isSubmitting}
+            className="!border-[#e5e7eb] !text-[#f47b20] !bg-transparent"
+          >
             Fechar
           </Button>
         </div>
+
       </div>
     </Modal>
   );

--- a/src/app/components/reports/SprintTable.tsx
+++ b/src/app/components/reports/SprintTable.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { LoaderCircle, Plus } from "lucide-react";
 import { api } from "../../services/api";
 import { useAuth } from "../../context/AuthContext";
@@ -181,7 +181,7 @@ export function SprintTable({ selectedProject = null }: SprintTableProps = {}) {
                 const isExpanded = expandedRowId === item.id;
 
                 return (
-                  <>
+                  <React.Fragment key={`${item.id_project}/${item.id}`}>
                     {/* Listagem de sprints */}
                     <tr
                       onClick={() => toggleRow(item.id)}
@@ -239,7 +239,7 @@ export function SprintTable({ selectedProject = null }: SprintTableProps = {}) {
                         </td>
                       </tr>
                     )}
-                  </>
+                  </React.Fragment>
                 );
               })}
             </tbody>

--- a/src/app/components/reports/SprintTable.tsx
+++ b/src/app/components/reports/SprintTable.tsx
@@ -14,6 +14,11 @@ interface SprintReportApiResponse {
   student: string;
   date: string;
   id_project: number;
+  predictedActivity?: string;
+  activityCompleted?: string;
+  problemsEncountered?: string;
+  learnedLessons?: string;
+  nextSteps?: string;
 }
 
 type RowStatus = "ENVIANDO" | "ENVIADO";
@@ -57,6 +62,8 @@ export function SprintTable({ selectedProject = null }: SprintTableProps = {}) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [expandedRowId, setExpandedRowId] = useState<number | null>(null);
+
   const { user } = useAuth();
   const { showToast } = useToast();
 
@@ -95,6 +102,11 @@ export function SprintTable({ selectedProject = null }: SprintTableProps = {}) {
       date: new Date().toISOString(),
       id_project: 0,
       status: "ENVIANDO",
+      predictedActivity: data.plannedActivities,
+      activityCompleted: data.completedActivities,
+      problemsEncountered: data.problems,
+      learnedLessons: data.lessonsLearned,
+      nextSteps: data.nextSteps,
     };
 
     setSprintReports((prev) => [...prev, optimisticRow]);
@@ -125,6 +137,10 @@ export function SprintTable({ selectedProject = null }: SprintTableProps = {}) {
     }
   };
 
+  const toggleRow = (id: number) => {
+    setExpandedRowId((prev) => (prev === id ? null : id));
+  };
+
   return (
     <>
       <div className="mb-4 flex justify-end">
@@ -153,43 +169,79 @@ export function SprintTable({ selectedProject = null }: SprintTableProps = {}) {
           <table className="w-full text-sm border-collapse">
             <thead className="bg-[#f9fafb] text-[#6b7280] border-b border-[#eef0f4]">
               <tr>
-                <th className="px-6 py-4 text-left font-semibold">Sprint</th>
-                <th className="px-6 py-4 text-left font-semibold">Estudante</th>
-                <th className="px-6 py-4 text-left font-semibold">Data</th>
-                <th className="px-6 py-4 text-center font-semibold">Status</th>
+                <th className="px-6 py-4 text-left font-semibold w-1/4">Sprint</th>
+                <th className="px-6 py-4 text-left font-semibold w-1/4">Estudante</th>
+                <th className="px-6 py-4 text-left font-semibold w-1/4">Data</th>
+                <th className="px-6 py-4 text-center font-semibold w-1/4">Status</th>
               </tr>
             </thead>
 
             <tbody className="bg-white">
-              {sprintReports.map((item) => (
-                <tr
-                  key={item.id}
-                  className="border-b border-[#eef0f4] hover:bg-slate-50/30 transition-colors last:border-b-0"
-                >
-                  <td className="px-6 py-4 font-medium text-slate-700">
-                    {item.sprint}
-                  </td>
+              {sprintReports.map((item) => {
+                const isExpanded = expandedRowId === item.id;
 
-                  <td className="px-6 py-4 text-slate-600">{item.student}</td>
+                return (
+                  <>
+                    {/* Listagem de sprints */}
+                    <tr
+                      onClick={() => toggleRow(item.id)}
+                      className={`cursor-pointer transition-colors ${
+                        isExpanded ? "bg-slate-50" : "hover:bg-slate-50/50"
+                      } ${!isExpanded ? "border-b border-[#eef0f4]" : ""}`}
+                    >
+                      <td className="px-6 py-4 font-medium text-slate-700">
+                        {item.sprint}
+                      </td>
+                      <td className="px-6 py-4 text-slate-600">{item.student}</td>
+                      <td className="px-6 py-4 text-slate-600">
+                        {new Date(item.date).toLocaleDateString("pt-BR")}
+                      </td>
+                      <td className="px-6 py-4 text-center">
+                        {item.status === "ENVIANDO" ? (
+                          <span className="inline-flex items-center gap-1.5 rounded-full bg-blue-50 border border-blue-100 px-2.5 py-1 text-xs font-bold text-blue-600">
+                            <LoaderCircle size={13} className="animate-spin" />
+                            Enviando
+                          </span>
+                        ) : (
+                          <span className="inline-flex items-center rounded-full bg-[#f0fdf4] border border-[#bbf7d0] px-2.5 py-1 text-xs font-bold text-[#22c55e]">
+                            Enviado
+                          </span>
+                        )}
+                      </td>
+                    </tr>
 
-                  <td className="px-6 py-4 text-slate-600">
-                    {new Date(item.date).toLocaleDateString("pt-BR")}
-                  </td>
-
-                  <td className="px-6 py-4 text-center">
-                    {item.status === "ENVIANDO" ? (
-                      <span className="inline-flex items-center gap-1.5 rounded-full bg-blue-50 border border-blue-100 px-2.5 py-1 text-xs font-bold text-blue-600">
-                        <LoaderCircle size={13} className="animate-spin" />
-                        Enviando
-                      </span>
-                    ) : (
-                      <span className="inline-flex items-center rounded-full bg-[#f0fdf4] border border-[#bbf7d0] px-2.5 py-1 text-xs font-bold text-[#22c55e]">
-                        Enviado
-                      </span>
+                    {/* Linha Expandida - detalhes do relatório */}
+                    {isExpanded && (
+                      <tr className="border-b border-[#eef0f4] bg-slate-50">
+                        <td colSpan={4} className="px-6 pb-6 pt-2 text-sm text-slate-700">
+                          <div className="flex flex-col gap-4 animate-in fade-in slide-in-from-top-2 duration-200">
+                            <p className="leading-relaxed text-justify">
+                              <strong className="text-slate-900">Atividades Previstas: </strong>
+                              {item.predictedActivity || "Nenhuma atividade prevista informada."}
+                            </p>
+                            <p className="leading-relaxed text-justify">
+                              <strong className="text-slate-900">Atividades Concluídas: </strong>
+                              {item.activityCompleted || "Nenhuma atividade concluída informada."}
+                            </p>
+                            <p className="leading-relaxed text-justify">
+                              <strong className="text-slate-900">Problemas Encontrados: </strong>
+                              {item.problemsEncountered || "Nenhum problema reportado."}
+                            </p>
+                            <p className="leading-relaxed text-justify">
+                              <strong className="text-slate-900">Lições aprendidas: </strong>
+                              {item.learnedLessons || "Nenhuma lição aprendida reportada."}
+                            </p>
+                            <p className="leading-relaxed text-justify">
+                              <strong className="text-slate-900">Próximos Passos: </strong>
+                              {item.nextSteps || "Nenhum próximo passo informado."}
+                            </p>
+                          </div>
+                        </td>
+                      </tr>
                     )}
-                  </td>
-                </tr>
-              ))}
+                  </>
+                );
+              })}
             </tbody>
           </table>
         </div>

--- a/src/app/components/reports/SprintTable.tsx
+++ b/src/app/components/reports/SprintTable.tsx
@@ -14,11 +14,11 @@ interface SprintReportApiResponse {
   student: string;
   date: string;
   id_project: number;
-  predictedActivity?: string;
-  activityCompleted?: string;
-  problemsEncountered?: string;
-  learnedLessons?: string;
-  nextSteps?: string;
+  predicted_activity?: string;
+  activity_completed?: string;
+  problems_encountered?: string;
+  learned_lessons?: string;
+  next_steps?: string;
 }
 
 type RowStatus = "ENVIANDO" | "ENVIADO";
@@ -102,11 +102,11 @@ export function SprintTable({ selectedProject = null }: SprintTableProps = {}) {
       date: new Date().toISOString(),
       id_project: 0,
       status: "ENVIANDO",
-      predictedActivity: data.plannedActivities,
-      activityCompleted: data.completedActivities,
-      problemsEncountered: data.problems,
-      learnedLessons: data.lessonsLearned,
-      nextSteps: data.nextSteps,
+      predicted_activity: data.plannedActivities,
+      activity_completed: data.completedActivities,
+      problems_encountered: data.problems,
+      learned_lessons: data.lessonsLearned,
+      next_steps: data.nextSteps,
     };
 
     setSprintReports((prev) => [...prev, optimisticRow]);
@@ -141,13 +141,13 @@ export function SprintTable({ selectedProject = null }: SprintTableProps = {}) {
     setExpandedRowId((prev) => (prev === id ? null : id));
   };
 
-  return (
+return (
     <>
-      <div className="mb-4 flex justify-end">
+      <div className="mb-4 mr-1 -mt-[60px] flex justify-end relative z-10 pointer-events-none">
         <button
           type="button"
           onClick={() => setIsModalOpen(true)}
-          className="inline-flex items-center gap-2 rounded-lg bg-[#3b5ccc] px-4 py-2 text-sm font-medium text-white hover:bg-[#2f4bb0] transition-colors cursor-pointer"
+          className="inline-flex items-center gap-2 rounded-lg bg-[#3b5ccc] px-4 py-2 text-sm font-medium text-white hover:bg-[#2f4bb0] transition-colors cursor-pointer pointer-events-auto"
         >
           <Plus size={16} />
           Novo Relatório
@@ -217,23 +217,23 @@ export function SprintTable({ selectedProject = null }: SprintTableProps = {}) {
                           <div className="flex flex-col gap-4 animate-in fade-in slide-in-from-top-2 duration-200">
                             <p className="leading-relaxed text-justify">
                               <strong className="text-slate-900">Atividades Previstas: </strong>
-                              {item.predictedActivity || "Nenhuma atividade prevista informada."}
+                              {item.predicted_activity || "Nenhuma atividade prevista informada."}
                             </p>
                             <p className="leading-relaxed text-justify">
                               <strong className="text-slate-900">Atividades Concluídas: </strong>
-                              {item.activityCompleted || "Nenhuma atividade concluída informada."}
+                              {item.activity_completed || "Nenhuma atividade concluída informada."}
                             </p>
                             <p className="leading-relaxed text-justify">
                               <strong className="text-slate-900">Problemas Encontrados: </strong>
-                              {item.problemsEncountered || "Nenhum problema reportado."}
+                              {item.problems_encountered || "Nenhum problema reportado."}
                             </p>
                             <p className="leading-relaxed text-justify">
                               <strong className="text-slate-900">Lições aprendidas: </strong>
-                              {item.learnedLessons || "Nenhuma lição aprendida reportada."}
+                              {item.learned_lessons || "Nenhuma lição aprendida reportada."}
                             </p>
                             <p className="leading-relaxed text-justify">
                               <strong className="text-slate-900">Próximos Passos: </strong>
-                              {item.nextSteps || "Nenhum próximo passo informado."}
+                              {item.next_steps || "Nenhum próximo passo informado."}
                             </p>
                           </div>
                         </td>

--- a/src/app/components/ui/InputField/InputField.tsx
+++ b/src/app/components/ui/InputField/InputField.tsx
@@ -6,6 +6,7 @@ interface InputFieldProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'o
   icon?: React.ReactNode;
   error?: string;
   onChange?: (value: string) => void;
+  mandatory?: boolean;
 }
 
 export const InputField: React.FC<InputFieldProps> = ({
@@ -16,6 +17,7 @@ export const InputField: React.FC<InputFieldProps> = ({
   disabled,
   className = '',
   onChange,
+  mandatory = false,
   ...props
 }) => {
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
@@ -25,19 +27,25 @@ export const InputField: React.FC<InputFieldProps> = ({
   const inputType = isPassword && isPasswordVisible ? 'text' : type;
 
   // Lógica para aplicar as classes dinamicamente com base no estado
-  let wrapperClasses = `flex items-center border rounded-lg px-3 py-2.5 bg-white transition-all duration-200 ease-in-out ${
-    error 
-      ? 'border-red-500' 
-      : isFocused 
-        ? 'border-blue-500 outline outline-1 outline-blue-500' 
-        : 'border-slate-300'
-  } ${disabled ? 'bg-slate-50 opacity-60' : ''}`;
+  let wrapperClasses = `flex items-center border rounded-lg px-3 py-2.5 transition-all duration-200 ease-in-out ${
+    disabled
+      ? 'bg-[#f4f5f6] border-[#e2e4e9]' // Estado disabled conforme o print (fundo cinza claro, borda sutil)
+      : error 
+        ? 'border-red-500 bg-white' 
+        : isFocused 
+          ? 'border-blue-500 ring-1 ring-blue-500 bg-white' 
+          : 'border-slate-300 bg-white'
+  }`;
 
   return (
     <div className={`flex flex-col w-full font-sans ${className}`}>
       {/* Label */}
       <label className="mb-1.5 text-sm font-semibold text-slate-700">
-        {label}
+        {
+          mandatory
+          ? <>{label}<span className="text-[#f47b20]">*</span></>
+          : <>{label}</>
+        }
       </label>
 
       {/* CONTAINER DO INPUT */}
@@ -45,7 +53,7 @@ export const InputField: React.FC<InputFieldProps> = ({
         
         {/* Ícone da esquerda */}
         {icon && (
-          <div className="flex items-center text-slate-400 mr-2.5">
+          <div className={`flex items-center mr-2.5 ${disabled ? 'text-slate-300' : 'text-slate-400'}`}>
             {icon}
           </div>
         )}
@@ -54,7 +62,9 @@ export const InputField: React.FC<InputFieldProps> = ({
         <input
           type={inputType}
           disabled={disabled}
-          className="flex-1 border-none outline-none bg-transparent text-sm text-slate-700 w-full disabled:cursor-not-allowed"
+          className={`flex-1 border-none outline-none bg-transparent text-sm disabled:cursor-not-allowed ${
+            disabled ? 'text-slate-400 placeholder-slate-300' : 'text-slate-700 placeholder-slate-400'
+          }`}
           onChange={(e) => onChange?.(e.target.value)}
           onFocus={(e) => {
             setIsFocused(true);
@@ -73,7 +83,9 @@ export const InputField: React.FC<InputFieldProps> = ({
             type="button"
             onClick={() => setIsPasswordVisible(!isPasswordVisible)}
             disabled={disabled}
-            className="flex items-center bg-transparent border-none cursor-pointer text-slate-400 ml-2.5 p-0 disabled:cursor-not-allowed hover:text-slate-600 transition-colors"
+            className={`flex items-center bg-transparent border-none cursor-pointer ml-2.5 p-0 transition-colors ${
+              disabled ? 'text-slate-300 cursor-not-allowed' : 'text-slate-400 hover:text-slate-600'
+            }`}
             aria-label={isPasswordVisible ? "Ocultar senha" : "Mostrar senha"}
           >
             {isPasswordVisible ? <EyeOff size={18} /> : <Eye size={18} />}
@@ -82,7 +94,7 @@ export const InputField: React.FC<InputFieldProps> = ({
       </div>
 
       {/* Mensagem de Erro */}
-      {error && (
+      {error && !disabled && (
         <span className="mt-1 text-xs text-red-500 font-medium">
           {error}
         </span>

--- a/src/app/components/ui/Modal/Modal.tsx
+++ b/src/app/components/ui/Modal/Modal.tsx
@@ -91,7 +91,7 @@ export function Modal({
         ref={modalRef}
         className={`relative bg-white p-6 rounded-xl w-full max-w-md z-[10000] shadow-2xl overflow-hidden ${className}`}
       >
-        <div className="absolute top-0 left-0 right-0 h-0.5 bg-gradient-to-r from-[#3b5ccc] to-[#5b7ae8] z-10 rounded-t-xl" />
+        <div className="absolute top-0 left-0 right-0 h-1 bg-gradient-to-r from-[#3b5ccc] to-[#5b7ae8] z-10 rounded-t-xl" />
         <div className="flex justify-between items-center">
           <h2 className="text-[24px] font-bold text-black">{title}</h2>
           <div className="flex items-center gap-2">
@@ -100,7 +100,6 @@ export function Modal({
                 {categoria}
               </span>
             )}
-            <button className="text-gray-500 hover:text-black font-bold px-2" onClick={onClose}>X</button>
           </div>
         </div>
 

--- a/src/app/components/ui/Select/Select.tsx
+++ b/src/app/components/ui/Select/Select.tsx
@@ -1,0 +1,55 @@
+import React, { SelectHTMLAttributes, forwardRef } from 'react';
+import { ChevronDown } from 'lucide-react';
+
+export interface SelectOption {
+  value: string | number;
+  label: string;
+}
+
+interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
+  options: SelectOption[];
+  placeholder?: string;
+  wrapperClassName?: string;
+}
+
+export const Select = forwardRef<HTMLSelectElement, SelectProps>(({
+  options,
+  placeholder,
+  wrapperClassName = '',
+  className = '',
+  ...props
+}, ref) => {
+  return (
+    <div className={`relative inline-block ${wrapperClassName}`}>
+      <select
+        ref={ref}
+        className={`
+          appearance-none h-[38px] pl-4 pr-9 rounded-lg
+          border border-[#e5e7eb] bg-white
+          text-[13px] text-[#6b7280] font-medium
+          focus:outline-none focus:ring-2 focus:ring-[#3b5ccc]/30 focus:border-[#3b5ccc]
+          cursor-pointer transition-colors
+          ${className}
+        `}
+        {...props}
+      >
+        {placeholder && (
+          <option value="">{placeholder}</option>
+        )}
+        
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+      
+      <ChevronDown
+        size={15}
+        className="absolute right-3 top-1/2 -translate-y-1/2 text-[#9ca3af] pointer-events-none"
+      />
+    </div>
+  );
+});
+
+Select.displayName = 'Select';

--- a/src/app/components/ui/Select/Select.tsx
+++ b/src/app/components/ui/Select/Select.tsx
@@ -4,6 +4,7 @@ import { ChevronDown } from 'lucide-react';
 export interface SelectOption {
   value: string | number;
   label: string;
+  disabled?: boolean;
 }
 
 interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
@@ -38,9 +39,9 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(({
         )}
         
         {options.map((option) => (
-          <option key={option.value} value={option.value}>
-            {option.label}
-          </option>
+            <option key={option.value} value={option.value} disabled={option.disabled}>
+                {option.label}
+            </option>
         ))}
       </select>
       

--- a/src/app/components/ui/Select/Select.tsx
+++ b/src/app/components/ui/Select/Select.tsx
@@ -25,7 +25,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(({
       <select
         ref={ref}
         className={`
-          appearance-none h-[38px] pl-4 pr-9 rounded-lg
+          appearance-none pl-4 pr-9 rounded-lg h-[38px] 
           border border-[#e5e7eb] bg-white
           text-[13px] text-[#6b7280] font-medium
           focus:outline-none focus:ring-2 focus:ring-[#3b5ccc]/30 focus:border-[#3b5ccc]

--- a/src/app/components/ui/TextArea/TextArea.tsx
+++ b/src/app/components/ui/TextArea/TextArea.tsx
@@ -6,6 +6,7 @@ interface TextAreaFieldProps extends Omit<TextareaHTMLAttributes<HTMLTextAreaEle
   onChange?: (value: string) => void;
   value?: string;
   maxLength?: number;
+  mandatory?: boolean;
 }
 
 export const TextArea: React.FC<TextAreaFieldProps> = ({
@@ -16,6 +17,7 @@ export const TextArea: React.FC<TextAreaFieldProps> = ({
   onChange,
   value = '',
   maxLength = 1250,
+  mandatory = false,
   ...props
 }) => {
   const [isFocused, setIsFocused] = useState(false);
@@ -40,7 +42,11 @@ export const TextArea: React.FC<TextAreaFieldProps> = ({
   return (
     <div className={`flex flex-col w-full font-sans ${className}`}>
       <label className="mb-1.5 text-sm font-semibold text-[#6B7280] cursor-text">
-        {label}
+        {
+          mandatory 
+          ? <>{label}<span className="text-[#f47b20]">*</span></>
+          : <>{label}</>
+        }
       </label>
 
       <div className={`

--- a/src/app/pages/RelatoriosPage.tsx
+++ b/src/app/pages/RelatoriosPage.tsx
@@ -10,6 +10,7 @@ import {
 import { Button } from "../components/ui/Button/Button";
 import { ReportUploadModal } from "../components/reports/ReportUploadModal";
 import { SprintTable } from "../components/reports/SprintTable";
+import { Select } from "../components/ui/Select/Select";
 
 type TabId = "horas" | "sprint" | "andamento" | "final";
 
@@ -225,34 +226,19 @@ export default function RelatoriosPage() {
         {/* Filtro compartilhado (Horas + Sprint) */}
         {currentTab.hasProjectFilter && (
           <div className="px-6 pt-5">
-            <div className="relative inline-block">
-              <select
-                value={selectedProject}
-                onChange={(e) =>
-                  setSelectedProject(
-                    e.target.value === "" ? "" : Number(e.target.value),
-                  )
-                }
-                className="
-                  appearance-none h-[38px] pl-4 pr-9 rounded-lg
-                  border border-[#e5e7eb] bg-white
-                  text-[13px] text-[#6b7280] font-medium
-                  focus:outline-none focus:ring-2 focus:ring-[#3b5ccc]/30 focus:border-[#3b5ccc]
-                  cursor-pointer transition-colors
-                "
-              >
-                <option value="">Filtrar por projeto</option>
-                {projects.map((p) => (
-                  <option key={p.id} value={p.id}>
-                    {p.name}
-                  </option>
-                ))}
-              </select>
-              <ChevronDown
-                size={15}
-                className="absolute right-3 top-1/2 -translate-y-1/2 text-[#9ca3af] pointer-events-none"
-              />
-            </div>
+            <Select
+              value={selectedProject ?? ""}
+              onChange={(e) =>
+                setSelectedProject(
+                  e.target.value === "" ? "" : Number(e.target.value)
+                )
+              }
+              placeholder="Filtrar por projeto"
+              options={projects.map((p) => ({
+                value: p.id,
+                label: p.name,
+              }))}
+            />
           </div>
         )}
 

--- a/src/app/pages/RelatoriosPage.tsx
+++ b/src/app/pages/RelatoriosPage.tsx
@@ -1,6 +1,6 @@
 import { api } from "../services/api";
 import { useEffect, useState } from "react";
-import { FileText, ChevronDown, FileDown, UploadCloud } from "lucide-react";
+import { FileText, FileDown, UploadCloud } from "lucide-react"; 
 import { HoursTable } from "../components/reports/HoursTable";
 import { HoursSummary } from "../components/reports/HoursSummary";
 import {
@@ -66,6 +66,7 @@ export default function RelatoriosPage() {
   const [finalReport, setFinalReport] = useState<ReportEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  
   const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
 
@@ -185,7 +186,6 @@ export default function RelatoriosPage() {
 
   return (
     <div className="flex flex-col gap-5">
-      {/* Cabeçalho */}
       <div className="flex items-center gap-2.5">
         <FileText size={20} className="text-[#3b5ccc]" strokeWidth={1.8} />
         <h2 className="text-[18px] font-bold text-[#1f2937] m-0 leading-none">
@@ -193,9 +193,7 @@ export default function RelatoriosPage() {
         </h2>
       </div>
 
-      {/* Card container */}
       <div className="bg-white rounded-2xl border border-[#e5e7eb]">
-        {/* Barra de abas */}
         <div className="sticky top-0 z-10 flex items-center border-b border-[#e5e7eb] px-6 bg-white rounded-t-2xl">
           <nav className="flex flex-1 gap-1" role="tablist">
             {TABS.map((tab) => {
@@ -223,10 +221,11 @@ export default function RelatoriosPage() {
           </nav>
         </div>
 
-        {/* Filtro compartilhado (Horas + Sprint) */}
         {currentTab.hasProjectFilter && (
           <div className="px-6 pt-5">
             <Select
+              wrapperClassName="w-[220px]"
+              className="w-[220px]"
               value={selectedProject ?? ""}
               onChange={(e) =>
                 setSelectedProject(
@@ -242,18 +241,11 @@ export default function RelatoriosPage() {
           </div>
         )}
 
-        {/* Slot – cada aba renderiza seu componente filho */}
         <div role="tabpanel" className="p-6">
           {activeTab === "horas" && (
             <>
-              {loading && (
-                <div className="text-center text-[#6b7280] py-10">
-                  Carregando registros...
-                </div>
-              )}
-              {!loading && error && (
-                <div className="text-center text-red-600 py-10">{error}</div>
-              )}
+              {loading && <div className="text-center text-[#6b7280] py-10">Carregando registros...</div>}
+              {!loading && error && <div className="text-center text-red-600 py-10">{error}</div>}
               {!loading && !error && (
                 <>
                   <HoursSummary data={hours} />
@@ -263,9 +255,7 @@ export default function RelatoriosPage() {
             </>
           )}
           {activeTab === "sprint" && (
-            <SprintTable
-              selectedProject={selectedProject === "" ? null : selectedProject}
-            />
+            <SprintTable selectedProject={selectedProject === "" ? null : selectedProject} />
           )}
           {activeTab === "andamento" && renderReportTab(progressReport)}
           {activeTab === "final" && renderReportTab(finalReport)}
@@ -277,9 +267,7 @@ export default function RelatoriosPage() {
         onClose={() => setIsUploadModalOpen(false)}
         reportType={activeTab === "final" ? "final" : "andamento"}
         currentProject={projects[0]?.name ?? ""}
-        onSuccess={() => {
-          setRefreshKey((k) => k + 1);
-        }}
+        onSuccess={() => setRefreshKey((k) => k + 1)}
       />
     </div>
   );


### PR DESCRIPTION
## Descrição das Alterações

### Expansão de Linha na Tabela de Sprint (US022)

* Implementação do comportamento de accordion na `SprintTable`, permitindo que a linha da tabela seja expandida ao clique.
* Inclusão do detalhamento completo do relatório (Atividades Previstas, Atividades Concluídas, Problemas Encontrados, Lições Aprendidas e Próximos Passos) na área expandida, formatado para ocupar toda a largura da tabela (via `colSpan`).
* Criação de controle de estado para garantir que apenas uma linha permaneça expandida por vez.
* Aplicação de animações sutis de transição na abertura do accordion para melhorar a fluidez visual.

### Refatoração e Novos Componentes Genéricos

* **Select Component:** Criação e isolamento do componente genérico `Select`, padronizando o visual e interações. Substituição das tags nativas `<select>` por este novo componente na tela de Relatórios e no modal de Sprint.
* **Input Disabled State:** Refatoração do visual do componente `InputField` quando inativo (`disabled`), substituindo a opacidade global por cores sólidas padronizadas (fundo cinza claro, borda e texto sutis) para adequação exata ao protótipo.
* **Indicador de Obrigatoriedade:** Atualização na renderização das labels nos formulários, isolando o asterisco em uma tag separada para aplicar a cor de destaque (laranja) apenas ao caractere, indicando campos obrigatórios.

### Ajustes no Modal de Relatório de Sprint

* Refatoração da área de ações (botões) do `SprintReportModal`.
* Remoção da borda superior e do alinhamento à direita, ajustando o layout para que os botões "Cadastrar" e "Fechar" ocupem proporções iguais (`fullWidth`), seguindo o Figma.