### PR TITLE
feat: reports page improvements

### DIFF
--- a/src/app/components/reports/HoursSummary.tsx
+++ b/src/app/components/reports/HoursSummary.tsx
@@ -5,15 +5,29 @@ interface HourEntry {
 interface HoursSummaryProps {
   data: HourEntry[];
   totalHours?: number;
+  isCurrentProject?: boolean;
 }
 
-export function HoursSummary({ data, totalHours = 60 }: HoursSummaryProps) {
+export function HoursSummary({
+  data,
+  totalHours = 60,
+  isCurrentProject = true,
+}: HoursSummaryProps) {
   const totalSeconds = totalHours * 3600;
   const doneSeconds = data.reduce(
     (acc, item) => acc + (item.sessionTimeSeconds ?? 0),
     0,
   );
   const remainingSeconds = Math.max(totalSeconds - doneSeconds, 0);
+
+  if (!isCurrentProject) {
+    return (
+      <div className="mb-4 rounded-lg bg-blue-50 px-4 py-3 text-sm text-[#3b5ccc]">
+        <span className="font-semibold">{formatHours(doneSeconds)} concluídas</span>{" "}
+        de {formatHours(totalSeconds)} totais.
+      </div>
+    );
+  }
 
   return (
     <div className="mb-4 rounded-lg bg-blue-50 px-4 py-3 text-sm text-[#3b5ccc]">

--- a/src/app/components/reports/SprintReportModal.tsx
+++ b/src/app/components/reports/SprintReportModal.tsx
@@ -9,6 +9,7 @@ interface SprintReportModalProps {
   onSubmit?: (data: SprintReportFormData) => void | Promise<void>;
   isSubmitting?: boolean;
   usedSprints?: string[];
+  projectName?: string;
 }
 
 export interface SprintReportFormData {
@@ -36,6 +37,7 @@ export function SprintReportModal({
   onSubmit,
   isSubmitting = false,
   usedSprints = [],
+  projectName = DEFAULT_PROJECT,
 }: SprintReportModalProps) {
   const [sprint, setSprint] = useState("");
   const [plannedActivities, setPlannedActivities] = useState("");
@@ -71,7 +73,7 @@ export function SprintReportModal({
     if (!isFormValid || isSubmitting) return;
 
     onSubmit?.({
-      project: DEFAULT_PROJECT,
+      project: projectName,
       sprint,
       plannedActivities,
       completedActivities,
@@ -107,7 +109,7 @@ export function SprintReportModal({
               </label>
 
               <input
-                value={DEFAULT_PROJECT}
+                value={projectName}
                 disabled
                 className="h-[42px] w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-sm text-slate-500"
               />
@@ -124,12 +126,20 @@ export function SprintReportModal({
                 className="h-[42px] w-full rounded-2xl border border-slate-200 bg-white px-4 text-sm text-slate-700 cursor-pointer focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
               >
                 <option value="">Selecione</option>
-                {SPRINT_OPTIONS.map((s) => (
-                  <option key={s} value={s} disabled={usedSet.has(s)}>
-                    {s}
-                    {usedSet.has(s) ? " (já enviada)" : ""}
-                  </option>
-                ))}
+                {SPRINT_OPTIONS.map((s) => {
+                  const isUsed = usedSet.has(s);
+                  return (
+                    <option
+                      key={s}
+                      value={s}
+                      disabled={isUsed}
+                      className={isUsed ? "text-slate-400 italic" : ""}
+                    >
+                      {s}
+                      {isUsed ? " (já enviada)" : ""}
+                    </option>
+                  );
+                })}
               </select>
               {availableSprints.length === 0 && (
                 <span className="mt-1 block text-xs text-slate-500">

--- a/src/app/components/reports/SprintTable.tsx
+++ b/src/app/components/reports/SprintTable.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { LoaderCircle, Plus } from "lucide-react";
+import { LoaderCircle } from "lucide-react";
 import { api } from "../../services/api";
 import { useAuth } from "../../context/AuthContext";
 import { useToast } from "../../context/ToastContext";
@@ -49,10 +49,20 @@ function toPayload(data: SprintReportFormData): SprintReportPayload {
 
 interface SprintTableProps {
   selectedProject?: number | null;
+  currentProjectId?: number | null;
+  currentProjectName?: string;
+  /** Permite que a página pai abra o modal externamente */
+  externalModalOpen?: boolean;
+  onExternalModalClose?: () => void;
 }
 
-export function SprintTable({ selectedProject = null }: SprintTableProps = {}) {
-  const [isModalOpen, setIsModalOpen] = useState(false);
+export function SprintTable({
+  selectedProject = null,
+  currentProjectId = null,
+  currentProjectName = "",
+  externalModalOpen = false,
+  onExternalModalClose,
+}: SprintTableProps = {}) {
   const [sprintReports, setSprintReports] = useState<SprintReportRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -93,12 +103,12 @@ export function SprintTable({ selectedProject = null }: SprintTableProps = {}) {
       sprint: data.sprint,
       student: user?.name ?? "",
       date: new Date().toISOString(),
-      id_project: 0,
+      id_project: currentProjectId ?? 0,
       status: "ENVIANDO",
     };
 
     setSprintReports((prev) => [...prev, optimisticRow]);
-    setIsModalOpen(false);
+    onExternalModalClose?.();
     setIsSubmitting(true);
 
     try {
@@ -127,17 +137,6 @@ export function SprintTable({ selectedProject = null }: SprintTableProps = {}) {
 
   return (
     <>
-      <div className="mb-4 flex justify-end">
-        <button
-          type="button"
-          onClick={() => setIsModalOpen(true)}
-          className="inline-flex items-center gap-2 rounded-lg bg-[#3b5ccc] px-4 py-2 text-sm font-medium text-white hover:bg-[#2f4bb0] transition-colors cursor-pointer"
-        >
-          <Plus size={16} />
-          Novo Relatório
-        </button>
-      </div>
-
       {loading ? (
         <div className="text-center text-[#6b7280] py-10">
           Carregando relatórios...
@@ -196,11 +195,12 @@ export function SprintTable({ selectedProject = null }: SprintTableProps = {}) {
       )}
 
       <SprintReportModal
-        isOpen={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
+        isOpen={externalModalOpen}
+        onClose={() => onExternalModalClose?.()}
         onSubmit={handleSubmit}
         isSubmitting={isSubmitting}
         usedSprints={sprintReports.map((r) => r.sprint)}
+        projectName={currentProjectName}
       />
     </>
   );

--- a/src/app/pages/RelatoriosPage.tsx
+++ b/src/app/pages/RelatoriosPage.tsx
@@ -70,18 +70,6 @@ export default function RelatoriosPage() {
   const [refreshKey, setRefreshKey] = useState(0);
   const currentProject = projects[0] ?? null;
 
-
-  // MOCK — remover antes de subir
-useEffect(() => {
-  const mockProjects = [
-    { id: 1, name: "Fluxo AGES 2.0 - Alunos" },
-    { id: 2, name: "Projeto Anterior" },
-  ];
-  setProjects(mockProjects);
-  setSelectedProject(mockProjects[0].id);
-  setLoading(false);
-}, []);
-
   useEffect(() => {
     api
       .get<ProjectOption[]>("/project/me")

--- a/src/app/pages/RelatoriosPage.tsx
+++ b/src/app/pages/RelatoriosPage.tsx
@@ -1,6 +1,6 @@
 import { api } from "../services/api";
 import { useEffect, useState } from "react";
-import { FileText, ChevronDown, FileDown, UploadCloud } from "lucide-react";
+import { FileText, ChevronDown, FileDown, UploadCloud, Plus } from "lucide-react";
 import { HoursTable } from "../components/reports/HoursTable";
 import { HoursSummary } from "../components/reports/HoursSummary";
 import {
@@ -58,7 +58,7 @@ function toReportEntry(report: ReportApiResponse): ReportEntry {
 
 export default function RelatoriosPage() {
   const [activeTab, setActiveTab] = useState<TabId>("horas");
-  const [selectedProject, setSelectedProject] = useState<number | "">("");
+  const [selectedProject, setSelectedProject] = useState<number | null>(null);
   const [projects, setProjects] = useState<ProjectOption[]>([]);
   const [hours, setHours] = useState<HourEntry[]>([]);
   const [progressReport, setProgressReport] = useState<ReportEntry[]>([]);
@@ -66,12 +66,33 @@ export default function RelatoriosPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
+  const [isSprintModalOpen, setIsSprintModalOpen] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
+  const currentProject = projects[0] ?? null;
+
+
+  // MOCK — remover antes de subir
+useEffect(() => {
+  const mockProjects = [
+    { id: 1, name: "Fluxo AGES 2.0 - Alunos" },
+    { id: 2, name: "Projeto Anterior" },
+  ];
+  setProjects(mockProjects);
+  setSelectedProject(mockProjects[0].id);
+  setLoading(false);
+}, []);
 
   useEffect(() => {
     api
       .get<ProjectOption[]>("/project/me")
-      .then((data) => setProjects(data ?? []))
+      .then((data) => {
+        const list = data ?? [];
+        setProjects(list);
+
+        if (list.length > 0) {
+          setSelectedProject(list[0].id);
+        }
+      })
       .catch((err) => {
         console.error("Erro ao buscar projetos:", err);
       });
@@ -84,7 +105,7 @@ export default function RelatoriosPage() {
       setLoading(true);
       setError(null);
       const path =
-        selectedProject === ""
+        selectedProject == null
           ? "/hours/me"
           : `/hours/me?id_project=${selectedProject}`;
       api
@@ -147,6 +168,9 @@ export default function RelatoriosPage() {
   }, [activeTab, refreshKey, selectedProject]);
 
   const currentTab = TABS.find((t) => t.id === activeTab)!;
+
+  const isCurrentProjectSelected =
+    currentProject == null || selectedProject === currentProject.id;
 
   const renderReportTab = (data: ReportEntry[]) => (
     <div className="flex flex-col gap-6">
@@ -222,26 +246,24 @@ export default function RelatoriosPage() {
           </nav>
         </div>
 
-        {/* Filtro compartilhado (Horas + Sprint) */}
         {currentTab.hasProjectFilter && (
-          <div className="px-6 pt-5">
+          <div className="px-6 pt-5 flex items-center justify-between">
             <div className="relative inline-block">
               <select
-                value={selectedProject}
+                value={selectedProject ?? ""}
                 onChange={(e) =>
                   setSelectedProject(
-                    e.target.value === "" ? "" : Number(e.target.value),
+                    e.target.value === "" ? null : Number(e.target.value),
                   )
                 }
                 className="
                   appearance-none h-[38px] pl-4 pr-9 rounded-lg
                   border border-[#e5e7eb] bg-white
-                  text-[13px] text-[#6b7280] font-medium
+                  text-[13px] text-[#374151] font-medium
                   focus:outline-none focus:ring-2 focus:ring-[#3b5ccc]/30 focus:border-[#3b5ccc]
                   cursor-pointer transition-colors
                 "
               >
-                <option value="">Filtrar por projeto</option>
                 {projects.map((p) => (
                   <option key={p.id} value={p.id}>
                     {p.name}
@@ -253,10 +275,20 @@ export default function RelatoriosPage() {
                 className="absolute right-3 top-1/2 -translate-y-1/2 text-[#9ca3af] pointer-events-none"
               />
             </div>
+
+            {activeTab === "sprint" && isCurrentProjectSelected && (
+              <button
+                type="button"
+                onClick={() => setIsSprintModalOpen(true)}
+                className="inline-flex items-center gap-2 rounded-lg bg-[#3b5ccc] px-4 py-2 text-sm font-medium text-white hover:bg-[#2f4bb0] transition-colors cursor-pointer"
+              >
+                <Plus size={16} />
+                Novo Relatório
+              </button>
+            )}
           </div>
         )}
 
-        {/* Slot – cada aba renderiza seu componente filho */}
         <div role="tabpanel" className="p-6">
           {activeTab === "horas" && (
             <>
@@ -270,7 +302,10 @@ export default function RelatoriosPage() {
               )}
               {!loading && !error && (
                 <>
-                  <HoursSummary data={hours} />
+                  <HoursSummary
+                    data={hours}
+                    isCurrentProject={isCurrentProjectSelected}
+                  />
                   <HoursTable data={hours} />
                 </>
               )}
@@ -278,7 +313,11 @@ export default function RelatoriosPage() {
           )}
           {activeTab === "sprint" && (
             <SprintTable
-              selectedProject={selectedProject === "" ? null : selectedProject}
+              selectedProject={selectedProject}
+              currentProjectId={currentProject?.id ?? null}
+              currentProjectName={currentProject?.name ?? ""}
+              externalModalOpen={isSprintModalOpen}
+              onExternalModalClose={() => setIsSprintModalOpen(false)}
             />
           )}
           {activeTab === "andamento" && renderReportTab(progressReport)}
@@ -290,7 +329,7 @@ export default function RelatoriosPage() {
         isOpen={isUploadModalOpen}
         onClose={() => setIsUploadModalOpen(false)}
         reportType={activeTab === "final" ? "final" : "andamento"}
-        currentProject={projects[0]?.name ?? ""}
+        currentProject={currentProject?.name ?? ""}
         onSuccess={() => {
           setRefreshKey((k) => k + 1);
         }}


### PR DESCRIPTION
## O que foi feito
Ajustes de comportamento e layout na tela de relatórios relacionados ao filtro de projeto, botão de novo relatório de sprint e componente HoursSummary.

## Arquivos alterados
- `src/app/pages/RelatoriosPage.tsx`
- `src/app/components/reports/HoursSummary.tsx`
- `src/app/components/reports/SprintReportModal.tsx`
- `src/app/components/reports/SprintTable.tsx`

## Como testar
1. Logar com o usuário de testes
2. Acessar a página de Relatórios
3. Verificar que o filtro de projeto já inicia selecionado no projeto atual (sem opção "Filtrar por projeto")
4. Na aba **Sprint**, confirmar que o botão "Novo Relatório" aparece à direita do filtro
5. Trocar o filtro para um projeto anterior e confirmar que o botão "Novo Relatório" desaparece
6. Voltar para o projeto atual, abrir o modal de novo relatório e confirmar que sprints já enviadas aparecem desabilitadas em cinza/itálico
7. Voltar para a aba **Horas** com um projeto anterior selecionado e confirmar que o `HoursSummary` exibe apenas `"Xh Ymin concluídas de Zh totais."`, sem a parte de restantes

## Checklist
- [x] Filtro de projeto inicializa selecionado no projeto atual, sem opção "Filtrar por projeto"
- [x] Botão "Novo Relatório" posicionado na mesma linha do filtro de projeto, à direita
- [x] Botão "Novo Relatório" na aba Sprint é ocultado quando o projeto selecionado não for o atual
- [x] `HoursSummary` exibe texto simplificado para projetos anteriores: `"Xh Ymin concluídas de Zh totais."`, sem a parte `— N restantes para concluir`
- [x] No modal de envio de relatório de sprint, sprints que já possuem relatório enviado aparecem desabilitadas e visualmente distintas (texto em cinza/itálico) no seletor

## Observações

- Durante o desenvolvimento foi utilizado um mock local de projetos para testes. Antes de testar, garantir que o usuário de testes possui ao menos um projeto vinculado no banco.