### PR TITLE
[US004] [Frontend] - Coluna "Devendo" na tabela de controle de horas

### DIFF
--- a/src/app/components/HoursTracker/HoursTracker.tsx
+++ b/src/app/components/HoursTracker/HoursTracker.tsx
@@ -49,6 +49,14 @@ export const HoursTracker = ({ hours, loading, error }: HoursTrackerProps) => {
             </p>
           </div>
           <div className="w-full h-full border-r border-[#e5e7eb] flex flex-col items-center justify-center">
+            <span className="text-[#f47b20] text-2xl font-bold leading-8">
+              {toHHMMSS(hours.owingSeconds)}
+            </span>
+            <p className="text-[#6b7280] text-center text-[11px] font-normal leading-[16.5px] m-0">
+              Devendo
+            </p>
+          </div>
+          <div className="w-full h-full border-r border-[#e5e7eb] flex flex-col items-center justify-center">
             <span className="text-[#1f2937] text-2xl font-bold leading-8">
               {toHHMMSS(hours.totalSeconds)}
             </span>

--- a/src/app/pages/ProjetoDetalhesPage.tsx
+++ b/src/app/pages/ProjetoDetalhesPage.tsx
@@ -1,4 +1,5 @@
 import {
+  ChevronRight,
   CircleCheckBig,
   ExternalLink,
   GitBranch,
@@ -292,7 +293,7 @@ function AgesStudents({ title, students }: AgesStudentsProps) {
     <details className="group">
       <summary className="flex items-center gap-1 cursor-pointer list-none text-sm font-bold text-[#1F2937]">
         <span className="text-[#3B5CCC] transition-transform group-open:rotate-90">
-          ▶
+          <ChevronRight />
         </span>
         {title}
       </summary>

--- a/src/app/pages/ProjetoDetalhesPage.tsx
+++ b/src/app/pages/ProjetoDetalhesPage.tsx
@@ -293,7 +293,7 @@ function AgesStudents({ title, students }: AgesStudentsProps) {
     <details className="group">
       <summary className="flex items-center gap-1 cursor-pointer list-none text-sm font-bold text-[#1F2937]">
         <span className="text-[#3B5CCC] transition-transform group-open:rotate-90">
-          <ChevronRight />
+          <ChevronRight size={16} />
         </span>
         {title}
       </summary>

--- a/src/app/types/dashboard.ts
+++ b/src/app/types/dashboard.ts
@@ -1,26 +1,27 @@
 export interface ProfileData {
-    id: number;
-    name: string;
-    email: string;
-    avatarUrl: string | null;
-    agesLevel: number;
-    currentProject: { id: number; name: string } | null;
-    professor: { id: number; name: string } | null;
-    attendance: {
-        totalClasses: number;
-        presences: number;
-        absences: number;
-    };
+  id: number;
+  name: string;
+  email: string;
+  avatarUrl: string | null;
+  agesLevel: number;
+  currentProject: { id: number; name: string } | null;
+  professor: { id: number; name: string } | null;
+  attendance: {
+    totalClasses: number;
+    presences: number;
+    absences: number;
+  };
 }
 
 export interface HoursData {
-    completedSeconds: number;
-    remainingSeconds: number;
-    totalSeconds: number;
-    percentual: number;
+  completedSeconds: number;
+  remainingSeconds: number;
+  totalSeconds: number;
+  owingSeconds: number;
+  percentual: number;
 }
 
 export interface DashboardResponse {
-    profile: ProfileData;
-    hours: HoursData;
+  profile: ProfileData;
+  hours: HoursData;
 }


### PR DESCRIPTION
Desenvolvimento da adição da coluna de "Devendo" no controle de horas na dashboard.

- Edição no componente `HoursTracker`: adição da seção "Devendo" que consome dados do campo `owingSeconds`
- Implementado na cor laranja, seguindo a mesma cor de outras horas que estão "devendo" também

Ajustes:

-  No componente `ProjetoDetalhesPage`, mudei do emoji de seta para o componente ChevronRight do Lucide React