### PR TITLE
feat(US025): Modal de edição de relatório de sprint

### DIFF
--- a/src/app/components/reports/SprintReportModal.tsx
+++ b/src/app/components/reports/SprintReportModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Modal } from "../ui/Modal/Modal";
 import { Button } from "../ui/Button/Button";
 import { TextArea } from "../ui/TextArea/TextArea";
+import { SprintReportFormData, SprintReportRow } from "@/app/types/sprintReport";
 
 interface SprintReportModalProps {
   isOpen: boolean;
@@ -9,16 +10,7 @@ interface SprintReportModalProps {
   onSubmit?: (data: SprintReportFormData) => void | Promise<void>;
   isSubmitting?: boolean;
   usedSprints?: string[];
-}
-
-export interface SprintReportFormData {
-  project: string;
-  sprint: string;
-  plannedActivities: string;
-  completedActivities: string;
-  problems: string;
-  lessonsLearned: string;
-  nextSteps: string;
+  initialData?: SprintReportRow | null;
 }
 
 const DEFAULT_PROJECT = "Fluxo AGES 2.0 - Alunos";
@@ -36,6 +28,7 @@ export function SprintReportModal({
   onSubmit,
   isSubmitting = false,
   usedSprints = [],
+  initialData = null,
 }: SprintReportModalProps) {
   const [sprint, setSprint] = useState("");
   const [plannedActivities, setPlannedActivities] = useState("");
@@ -45,7 +38,14 @@ export function SprintReportModal({
   const [nextSteps, setNextSteps] = useState("");
 
   useEffect(() => {
-    if (!isOpen) {
+    if (isOpen) {
+      setSprint(initialData?.sprint ?? "");
+      setPlannedActivities(initialData?.predicted_activity ?? "");
+      setCompletedActivities(initialData?.activity_completed ?? "");
+      setProblems(initialData?.problems_encountered ?? "");
+      setLessonsLearned(initialData?.learned_lessons ?? "");
+      setNextSteps(initialData?.next_steps ?? "");
+    } else {
       setSprint("");
       setPlannedActivities("");
       setCompletedActivities("");
@@ -53,7 +53,7 @@ export function SprintReportModal({
       setLessonsLearned("");
       setNextSteps("");
     }
-  }, [isOpen]);
+  }, [isOpen, initialData]);
 
   const usedSet = new Set(usedSprints);
   const availableSprints = SPRINT_OPTIONS.filter((s) => !usedSet.has(s));
@@ -85,10 +85,10 @@ export function SprintReportModal({
     <Modal
       isOpen={isOpen}
       onClose={onClose}
-      title="Relatório de Sprint"
-      className="!max-w-2xl"
+      title={initialData ? "Atualizar Relatório de Sprint" : "Relatório de Sprint"}
+      className="!w-[550px] !max-w-[550px]"
     >
-      <div className="mt-4 flex max-h-[70vh] w-[640px] max-w-full flex-col">
+      <div className="mt-4 flex h-[640px] max-h-[70vh] max-w-full flex-col">
         <div
           className="
             flex flex-col gap-4 overflow-y-auto pr-2
@@ -121,7 +121,8 @@ export function SprintReportModal({
               <select
                 value={sprint}
                 onChange={(e) => setSprint(e.target.value)}
-                className="h-[42px] w-full rounded-2xl border border-slate-200 bg-white px-4 text-sm text-slate-700 cursor-pointer focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+                disabled={!!initialData}
+                className="h-[42px] w-full rounded-2xl border border-slate-200 bg-white px-4 text-sm text-slate-700 cursor-pointer focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500 disabled:bg-slate-50 disabled:text-slate-500 disabled:cursor-not-allowed"
               >
                 <option value="">Selecione</option>
                 {SPRINT_OPTIONS.map((s) => (
@@ -131,7 +132,7 @@ export function SprintReportModal({
                   </option>
                 ))}
               </select>
-              {availableSprints.length === 0 && (
+              {!initialData && availableSprints.length === 0 && (
                 <span className="mt-1 block text-xs text-slate-500">
                   Todas as sprints já possuem relatório.
                 </span>
@@ -170,17 +171,17 @@ export function SprintReportModal({
           />
         </div>
 
-        <div className="mt-4 flex justify-end gap-3 border-t border-[#e5e7eb] pt-4">
+        <div className="mt-4 grid grid-cols-2 gap-3 border-t border-[#e5e7eb] pt-4">
           <Button
-            variant="primary"
+            variant="accent"
             onClick={handleSubmit}
             disabled={!isFormValid || isSubmitting}
             loading={isSubmitting}
           >
-            {isSubmitting ? "Enviando..." : "Cadastrar"}
+            {isSubmitting ? "Enviando..." : initialData ? "Atualizar Relatório" : "Cadastrar"}
           </Button>
 
-          <Button variant="secondary" onClick={onClose} disabled={isSubmitting}>
+          <Button variant="accent-secondary" onClick={onClose} disabled={isSubmitting}>
             Fechar
           </Button>
         </div>

--- a/src/app/components/reports/SprintTable.tsx
+++ b/src/app/components/reports/SprintTable.tsx
@@ -1,35 +1,15 @@
 import { useEffect, useState } from "react";
-import { LoaderCircle, Plus } from "lucide-react";
+import { Pencil, LoaderCircle, Plus } from "lucide-react";
 import { api } from "../../services/api";
 import { useAuth } from "../../context/AuthContext";
 import { useToast } from "../../context/ToastContext";
+import { SprintReportModal } from "./SprintReportModal";
 import {
-  SprintReportModal,
-  type SprintReportFormData,
-} from "./SprintReportModal";
-
-interface SprintReportApiResponse {
-  id: number;
-  sprint: string;
-  student: string;
-  date: string;
-  id_project: number;
-}
-
-type RowStatus = "ENVIANDO" | "ENVIADO";
-
-interface SprintReportRow extends SprintReportApiResponse {
-  status: RowStatus;
-}
-
-interface SprintReportPayload {
-  sprint: number;
-  predictedActivity: string;
-  activityCompleted: string;
-  problemsEncountered: string;
-  learnedLessons: string;
-  nextSteps: string;
-}
+  SprintReportApiResponse,
+  SprintReportFormData,
+  SprintReportPayload,
+  SprintReportRow,
+} from "@/app/types/sprintReport";
 
 function parseSprintNumber(value: string): number {
   const match = value.match(/\d+/);
@@ -47,6 +27,16 @@ function toPayload(data: SprintReportFormData): SprintReportPayload {
   };
 }
 
+function toEditPayload(data: SprintReportFormData) {
+  return {
+    predictedActivity: data.plannedActivities,
+    activityCompleted: data.completedActivities,
+    problemsEncountered: data.problems,
+    learnedLessons: data.lessonsLearned,
+    nextSteps: data.nextSteps,
+  };
+}
+
 interface SprintTableProps {
   selectedProject?: number | null;
 }
@@ -54,6 +44,7 @@ interface SprintTableProps {
 export function SprintTable({ selectedProject = null }: SprintTableProps = {}) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [sprintReports, setSprintReports] = useState<SprintReportRow[]>([]);
+  const [reportToEdit, setReportToEdit] = useState<SprintReportRow | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -86,7 +77,12 @@ export function SprintTable({ selectedProject = null }: SprintTableProps = {}) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedProject]);
 
-  const handleSubmit = async (data: SprintReportFormData) => {
+  const handleUpdate = (report: SprintReportRow) => {
+    setReportToEdit(report);
+    setIsModalOpen(true);
+  };
+
+  const handleCreateReport = async (data: SprintReportFormData) => {
     const optimisticId = -Date.now();
     const optimisticRow: SprintReportRow = {
       id: optimisticId,
@@ -95,6 +91,11 @@ export function SprintTable({ selectedProject = null }: SprintTableProps = {}) {
       date: new Date().toISOString(),
       id_project: 0,
       status: "ENVIANDO",
+      predicted_activity: "",
+      activity_completed: "",
+      problems_encountered: "",
+      learned_lessons: "",
+      next_steps: "",
     };
 
     setSprintReports((prev) => [...prev, optimisticRow]);
@@ -102,8 +103,6 @@ export function SprintTable({ selectedProject = null }: SprintTableProps = {}) {
     setIsSubmitting(true);
 
     try {
-      await new Promise((resolve) => setTimeout(resolve, 3000));
-
       await api.post("/report/sprint", toPayload(data));
       showToast({
         variant: "success",
@@ -122,6 +121,40 @@ export function SprintTable({ selectedProject = null }: SprintTableProps = {}) {
       });
     } finally {
       setIsSubmitting(false);
+    }
+  };
+
+  const handleEditReport = async (data: SprintReportFormData) => {
+    setIsModalOpen(false);
+    setIsSubmitting(true);
+
+    try {
+      await api.put(`/report/sprint/${reportToEdit?.id}`, toEditPayload(data));
+      showToast({
+        variant: "success",
+        title: "Relatório atualizado",
+        message: "Relatório de sprint atualizado com sucesso.",
+      });
+      fetchReports();
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Erro ao atualizar relatório.";
+      showToast({
+        variant: "error",
+        title: "Erro ao atualizar",
+        message,
+      });
+    } finally {
+      setIsSubmitting(false);
+      setReportToEdit(null);
+    }
+  };
+
+  const handleSubmit = (data: SprintReportFormData) => {
+    if (reportToEdit) {
+      handleEditReport(data);
+    } else {
+      handleCreateReport(data);
     }
   };
 
@@ -157,6 +190,7 @@ export function SprintTable({ selectedProject = null }: SprintTableProps = {}) {
                 <th className="px-6 py-4 text-left font-semibold">Estudante</th>
                 <th className="px-6 py-4 text-left font-semibold">Data</th>
                 <th className="px-6 py-4 text-center font-semibold">Status</th>
+                <th className="px-6 py-4 text-center font-semibold">Ações</th>
               </tr>
             </thead>
 
@@ -188,6 +222,17 @@ export function SprintTable({ selectedProject = null }: SprintTableProps = {}) {
                       </span>
                     )}
                   </td>
+
+                  <td className="px-6 py-4 text-center">
+                    <button
+                      type="button"
+                      onClick={() => handleUpdate(item)}
+                      disabled={item.status === "ENVIANDO"}
+                      className="px-3 py-1 text-xs font-medium text-[#3b5ccc] cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+                    >
+                      <Pencil size={20} strokeWidth={3} />
+                    </button>
+                  </td>
                 </tr>
               ))}
             </tbody>
@@ -197,10 +242,14 @@ export function SprintTable({ selectedProject = null }: SprintTableProps = {}) {
 
       <SprintReportModal
         isOpen={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
+        onClose={() => {
+          setIsModalOpen(false);
+          setTimeout(() => setReportToEdit(null), 300);
+        }}
         onSubmit={handleSubmit}
         isSubmitting={isSubmitting}
         usedSprints={sprintReports.map((r) => r.sprint)}
+        initialData={reportToEdit}
       />
     </>
   );

--- a/src/app/components/ui/Button/Button.tsx
+++ b/src/app/components/ui/Button/Button.tsx
@@ -1,6 +1,6 @@
 import { ButtonHTMLAttributes } from "react";
 
-type ButtonVariant = "primary" | "secondary" | "ghost";
+type ButtonVariant = "primary" | "secondary" | "ghost" | "accent" | "accent-secondary";
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: ButtonVariant;
@@ -10,9 +10,10 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 
 const variantClasses: Record<ButtonVariant, string> = {
   primary: "bg-primary text-white hover:bg-primary/90 active:bg-primary/80",
-  secondary:
-    "border border-primary text-primary bg-transparent hover:bg-primary/10 active:bg-primary/15",
+  secondary: "border border-primary text-primary bg-transparent hover:bg-primary/10 active:bg-primary/15",
   ghost: "bg-transparent text-primary hover:underline px-1",
+  accent: "bg-accent text-white hover:bg-accent/90 active:bg-accent/80",
+  "accent-secondary": "border border-accent text-accent bg-transparent hover:bg-accent/10 active:bg-accent/15"
 };
 
 export function Button({

--- a/src/app/components/ui/Modal/Modal.tsx
+++ b/src/app/components/ui/Modal/Modal.tsx
@@ -83,7 +83,7 @@ export function Modal({
   return (
     <div
       className={`fixed inset-0 bg-black/50 flex justify-center items-center z-[9999] p-4 transition-opacity duration-300 ${isOpen ? "opacity-100" : "opacity-0"}`}
-      onClick={(e) => {
+      onMouseDown={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
     >

--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -35,4 +35,6 @@ export const api = {
   get: <T>(path: string) => request<T>(path),
   post: <T>(path: string, body: unknown) =>
     request<T>(path, { method: "POST", body: JSON.stringify(body) }),
+  put: <T>(path: string, body: unknown) =>
+    request<T>(path, { method: "PUT", body: JSON.stringify(body) }),
 };

--- a/src/app/types/sprintReport.ts
+++ b/src/app/types/sprintReport.ts
@@ -1,0 +1,37 @@
+export interface SprintReportApiResponse {
+    id: number;
+    sprint: string;
+    student: string;
+    date: string;
+    id_project: number;
+    predicted_activity: string;
+    activity_completed: string;
+    problems_encountered: string;
+    learned_lessons: string;
+    next_steps: string;
+}
+
+export type RowStatus = "ENVIANDO" | "ENVIADO";
+
+export interface SprintReportRow extends SprintReportApiResponse {
+    status: RowStatus;
+}
+
+export interface SprintReportPayload {
+    sprint: number;
+    predictedActivity: string;
+    activityCompleted: string;
+    problemsEncountered: string;
+    learnedLessons: string;
+    nextSteps: string;
+}
+
+export interface SprintReportFormData {
+    project: string;
+    sprint: string;
+    plannedActivities: string;
+    completedActivities: string;
+    problems: string;
+    lessonsLearned: string;
+    nextSteps: string;
+}


### PR DESCRIPTION
## Sumário
Implementada funcionalidade de edição de relatórios de sprint no frontend.

A funcionalidade permite que o aluno edite um relatório de sprint existente diretamente pela tabela de relatórios. Foi adicionada uma coluna de ações com botão de editar que abre o modal já preenchido com os dados do relatório selecionado. O modal existente de criação foi reutilizado para suportar os dois modos — criação e edição — diferenciando o comportamento através da prop `initialData`. A lógica de submissão foi separada em `handleCreateReport` e `handleEditReport`, onde o `handleEditReport` envia apenas os campos editáveis aceitos pelo endpoint. 
Também foram corrigidos dois bugs do modal: 
-O modal fechava sozinho ao clicar para selecionar um texto e arrastar o mouse para fora do modal.
-O título ficava piscando durante a animação de fechamento e o modal de atualização mudava o título por milésimos de segundos para "Relatório de Sprint" antes de fechar. 

Por fim, as interfaces relacionadas ao relatório de sprint foram centralizadas no arquivo `types/sprintReport.ts`.

## Observações

- O campo `sprint` é desabilitado no modo edição, pois o backend não aceita alteração do número da sprint via `PUT`.
- Nova cor laranja para os botões. Estão em `Button.tsx` com o nome de `accent` e `accent-secondary`.
- O `setReportToEdit(null)` no fechamento do modal utiliza `setTimeout` de 300ms para aguardar a animação e evitar o título piscando.
- Adicionado os campos de edição a interface `SprintReportApiResponse`. 
- Task integrada.

## Regras implementadas

- Adição de coluna de ações com botão de editar na tabela de sprints.
- Reutilização do `SprintReportModal` para criação e edição.
- Separação da lógica de criação (`handleCreateReport`) e edição (`handleEditReport`).
- Envio apenas dos campos permitidos pelo `PUT /report/sprint/:id`.
- Preenchimento automático do formulário com dados do relatório selecionado.
- Desabilitação do select de sprint no modo edição.
- Título dinâmico do modal conforme o modo atual.
- Correção de fechamento indevido do modal ao arrastar texto.
- Correção de pisca no título durante animação de fechamento.
- Centralização das interfaces em `types/sprintReport.ts`.
