### PR TITLE
Merge para deploy com S3

### DIFF
--- a/src/app/components/reports/ReportUploadModal.tsx
+++ b/src/app/components/reports/ReportUploadModal.tsx
@@ -3,7 +3,13 @@ import { Modal } from "../ui/Modal/Modal";
 import { Upload, Check, XCircle } from "lucide-react";
 import toast from "react-hot-toast";
 import { useAuth } from "../../context/AuthContext";
-import { api } from "../../services/api";
+import {
+  confirmFinalReportUpload,
+  confirmProgressReportUpload,
+  createFinalReportUploadUrl,
+  createProgressReportUploadUrl,
+  uploadFileToPresignedUrl,
+} from "../../services/reportUpload";
 
 const MAX_FILE_SIZE_BYTES = 25 * 1024 * 1024;
 
@@ -27,9 +33,16 @@ export const ReportUploadModal = ({
   const { user } = useAuth();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  const clearSelectedFile = () => {
+    setSelectedFile(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
   useEffect(() => {
     if (!isOpen) {
-      setSelectedFile(null);
+      clearSelectedFile();
     }
   }, [isOpen]);
 
@@ -65,6 +78,24 @@ export const ReportUploadModal = ({
     );
   };
 
+  const getErrorMessage = (error: unknown, fallback: string) => {
+    if (error instanceof Error && error.message) {
+      return error.message;
+    }
+
+    return fallback;
+  };
+
+  const formatStageError = (error: unknown, fallback: string) => {
+    const message = getErrorMessage(error, "").trim();
+
+    if (!message || message === fallback || /^HTTP \d+$/.test(message)) {
+      return fallback;
+    }
+
+    return `${fallback} ${message}`;
+  };
+
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (!file) return;
@@ -75,37 +106,85 @@ export const ReportUploadModal = ({
 
     if (!isPdf) {
       showToast("error", "Selecione um arquivo PDF.");
-      setSelectedFile(null);
+      clearSelectedFile();
       return;
     }
 
     if (file.size > MAX_FILE_SIZE_BYTES) {
       showToast("error", "Arquivo excede o limite de 25MB.");
-      setSelectedFile(null);
+      clearSelectedFile();
       return;
     }
 
     setSelectedFile(file);
   };
 
+  const getUploadUrl = async () => {
+    try {
+      return reportType === "final"
+        ? await createFinalReportUploadUrl()
+        : await createProgressReportUploadUrl();
+    } catch (error) {
+      throw new Error(
+        formatStageError(
+          error,
+          "Não foi possível gerar a URL de upload do relatório.",
+        ),
+      );
+    }
+  };
+
+  const confirmUpload = async (fileReference: string) => {
+    try {
+      if (reportType === "final") {
+        await confirmFinalReportUpload(fileReference);
+        return;
+      }
+
+      await confirmProgressReportUpload(fileReference);
+    } catch (error) {
+      throw new Error(
+        formatStageError(
+          error,
+          reportType === "final"
+            ? "Não foi possível confirmar o upload do relatório final."
+            : "Não foi possível confirmar o upload do relatório de andamento.",
+        ),
+      );
+    }
+  };
+
   const handleUpload = async () => {
     if (!selectedFile) return;
     setIsUploading(true);
+
     try {
-      const formData = new FormData();
-      formData.append("file", selectedFile);
-      
-      const endpoint = reportType === "final" ? "/report/final" : "/report/progress";
-      
-      await api.post(endpoint, formData);
-      
+      const uploadData = await getUploadUrl();
+
+      try {
+        await uploadFileToPresignedUrl(
+          uploadData.uploadUrl,
+          selectedFile,
+          uploadData.contentType || "application/pdf",
+        );
+      } catch (error) {
+        throw new Error(
+          formatStageError(
+            error,
+            "Não foi possível enviar o PDF para o armazenamento.",
+          ),
+        );
+      }
+
+      await confirmUpload(uploadData.fileReference);
+
       showToast("success", "Relatório enviado com sucesso!");
       onSuccess();
       onClose();
-      setSelectedFile(null);
+      clearSelectedFile();
     } catch (error) {
       console.error("Erro ao enviar relatório:", error);
-      showToast("error", "Falha no envio do relatório.");
+      showToast("error", getErrorMessage(error, "Falha no envio do relatório."));
     } finally {
       setIsUploading(false);
     }

--- a/src/app/services/reportUpload.ts
+++ b/src/app/services/reportUpload.ts
@@ -1,0 +1,57 @@
+import { api } from "./api";
+
+export interface ReportUploadUrlResponse {
+  uploadUrl: string;
+  fileReference: string;
+  method: string;
+  contentType: string;
+}
+
+export interface ReportArchiveResponse {
+  id: number;
+  archiveUrl: string;
+  createdAt: string;
+}
+
+export function createProgressReportUploadUrl() {
+  return api.post<ReportUploadUrlResponse>(
+    "/report/progress/upload-url",
+    undefined,
+  );
+}
+
+export function createFinalReportUploadUrl() {
+  return api.post<ReportUploadUrlResponse>("/report/final/upload-url", undefined);
+}
+
+export async function uploadFileToPresignedUrl(
+  uploadUrl: string,
+  file: File,
+  contentType: string,
+) {
+  const response = await fetch(uploadUrl, {
+    method: "PUT",
+    headers: {
+      "Content-Type": contentType,
+    },
+    body: file,
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Falha ao enviar arquivo para o armazenamento (${response.status}).`,
+    );
+  }
+}
+
+export function confirmProgressReportUpload(fileReference: string) {
+  return api.post<ReportArchiveResponse>("/report/progress/confirm", {
+    fileReference,
+  });
+}
+
+export function confirmFinalReportUpload(fileReference: string) {
+  return api.post<ReportArchiveResponse>("/report/final/confirm", {
+    fileReference,
+  });
+}


### PR DESCRIPTION
## Resumo

Merge da `dev` para `main` com o novo fluxo de upload de relatórios diretamente para o S3 usando URL pré-assinada.

- Atualiza o upload de relatórios para usar o fluxo:
  `upload-url -> PUT direto no S3 -> confirm`
- Envia o PDF diretamente para a URL pré-assinada retornada pelo backend.
- Confirma o upload no backend usando o `fileReference`.
- Mantém validação de tipo PDF e limite de tamanho.
- Atualiza o comportamento da tela para refletir sucesso/erro no novo fluxo.

## Configurações AWS

- Variáveis/Secrets da Lambda configuradas para S3.
- Permissões IAM da role da Lambda ajustadas para o bucket/prefixo de produção.
- CORS do bucket S3 configurado para permitir upload direto pelo domínio do frontend.
- API Gateway mantido com rota proxy `/{proxy+}`, sem necessidade de cadastrar novas rotas manualmente.

## Testes pós-deploy

- Fazer upload de relatório pelo frontend.
- Confirmar criação do objeto em `prod/reports/...` no S3.
- Confirmar listagem/acesso do relatório pela aplicação.
- Remover relatório e validar exclusão no banco e no S3.